### PR TITLE
Remove preprocessor def for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,6 @@ conan_cmake_run(CONANFILE conan/conanfile.txt
         BUILD_TYPE "None"
         BUILD outdated)
 
-# This preprocessor definition is required for using HDF5 with MSVC
-add_definitions(-DH5_BUILT_AS_DYNAMIC_LIB)
-
 include(CTest)
 enable_testing()
 

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-hdf5/1.10.2@ess-dmsc/stable
+hdf5-dm1/1.10.2@ess-dmsc/stable
 librdkafka/0.11.3-dm3@ess-dmsc/testing
 gtest/3121b20-dm3@ess-dmsc/stable
 cli11/1.3.0@bincrafters/stable

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-hdf5-dm1/1.10.2@ess-dmsc/stable
+hdf5/1.10.2-dm1@ess-dmsc/stable
 librdkafka/0.11.3-dm3@ess-dmsc/testing
 gtest/3121b20-dm3@ess-dmsc/stable
 cli11/1.3.0@bincrafters/stable


### PR DESCRIPTION
The conan recipe for HDF5 now handles adding the required preprocessor definition, so it can be removed from cmake here.