### PR TITLE
Add profiling using gperftools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,20 +24,43 @@ conan_cmake_run(CONANFILE conan/conanfile.txt
 include(CTest)
 enable_testing()
 
+find_package(Gperftools)
+
 #####################
 ## Doxygen         ##
 #####################
 
 # add a target to generate API documentation with Doxygen
 find_package(Doxygen)
-if(DOXYGEN_FOUND)
+if(DOXYGEN_FOUND AND BUILD_DOCS)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
     add_custom_target(doc
             ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             COMMENT "Generating API documentation with Doxygen" VERBATIM
             )
-endif(DOXYGEN_FOUND)
+endif()
+
+#####################
+## TCMalloc        ##
+#####################
+# if tcmalloc is available then link all executables against it
+if (GPERFTOOLS_TCMALLOC AND NOT BUILD_DOCS)
+    MESSAGE("Linking all executables with tcmalloc")
+    macro (add_executable _name)
+        # invoke built-in add_executable
+        _add_executable(${ARGV})
+        if (PROFILE)
+            if (TARGET ${_name})
+                target_link_libraries(${_name} ${GPERFTOOLS_TCMALLOC_AND_PROFILER})
+            endif()
+         else ()
+            if (TARGET ${_name})
+                target_link_libraries(${_name} ${GPERFTOOLS_TCMALLOC})
+            endif()
+        endif()
+    endmacro()
+endif()
 
 
 ####################

--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ Use pprof to display the information. For example, to display as an SVG map in t
 ```
 google-pprof -web <path/to/binary> /tmp/prof.out
 ```
-Note, this works only on Linux with google perftools installed (tcmalloc and pprof).
+Note, this requires google perftools installed (tcmalloc and pprof). `gperftools` can be installed with Homebrew on OS X, or system repositories for most Linux distros.

--- a/README.md
+++ b/README.md
@@ -77,3 +77,15 @@ from the build directory.
 
 ## Schema
 The message schema files are located in https://github.com/ess-dmsc/streaming-data-types
+
+## Profiling
+CPU profiling can be performed by running the executable with `CPUPROFILE` environment variable set and specifying cmake parameter `PROFILE=true`.
+For example:
+```
+CPUPROFILE=/tmp/prof.out <path/to/binary> [binary args]
+```  
+Use pprof to display the information. For example, to display as an SVG map in the browser:
+```
+google-pprof -web <path/to/binary> /tmp/prof.out
+```
+Note, this works only on Linux with google perftools installed (tcmalloc and pprof).

--- a/cmake/FindGperftools.cmake
+++ b/cmake/FindGperftools.cmake
@@ -1,0 +1,51 @@
+# Tries to find Gperftools.
+#
+# Usage of this module as follows:
+#
+#     find_package(Gperftools)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  Gperftools_ROOT_DIR  Set this variable to the root installation of
+#                       Gperftools if the module has problems finding
+#                       the proper installation path.
+#
+# Variables defined by this module:
+#
+#  GPERFTOOLS_FOUND              System has Gperftools libs/headers
+#  GPERFTOOLS_LIBRARIES          The Gperftools libraries (tcmalloc & profiler)
+#  GPERFTOOLS_INCLUDE_DIR        The location of Gperftools headers
+
+find_library(GPERFTOOLS_TCMALLOC
+        NAMES tcmalloc
+        HINTS ${Gperftools_ROOT_DIR}/lib)
+
+find_library(GPERFTOOLS_PROFILER
+        NAMES profiler
+        HINTS ${Gperftools_ROOT_DIR}/lib)
+
+find_library(GPERFTOOLS_TCMALLOC_AND_PROFILER
+        NAMES tcmalloc_and_profiler
+        HINTS ${Gperftools_ROOT_DIR}/lib)
+
+find_path(GPERFTOOLS_INCLUDE_DIR
+        NAMES gperftools/heap-profiler.h
+        HINTS ${Gperftools_ROOT_DIR}/include)
+
+set(GPERFTOOLS_LIBRARIES ${GPERFTOOLS_TCMALLOC_AND_PROFILER})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+        Gperftools
+        DEFAULT_MSG
+        GPERFTOOLS_LIBRARIES
+        GPERFTOOLS_INCLUDE_DIR)
+
+mark_as_advanced(
+        Gperftools_ROOT_DIR
+        GPERFTOOLS_TCMALLOC
+        GPERFTOOLS_PROFILER
+        GPERFTOOLS_TCMALLOC_AND_PROFILER
+        GPERFTOOLS_LIBRARIES
+        GPERFTOOLS_INCLUDE_DIR)


### PR DESCRIPTION
### Description of work

Changes make it easy to CPU profile with gperftools. The process is documented in the readme.
I've had questions from several people about how to do CPU profiling, so this repository can serve as an example.

### Acceptance Criteria

Pass on Jenkins. Reviewer could follow procedure described in readme and check they can get CPU profiling output (requires Linux or OS X).
Assuming you have Kafka running on `localhost`, run the following from the build directory:
```
CPUPROFILE=/tmp/prof.out bin/main_nexusPublisher --filename /path/to/data/SANS_test_uncompressed.hdf5 --detspecmap /path/to/data/spectrum_gastubes_01.dat --broker localhost --instrument SANS2D --singlerun
google-pprof -web bin/main_nexusPublisher /tmp/prof.out
```

### Unit Tests

N.A.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
