### PR TITLE
Improve message serialisation performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,12 +82,11 @@ include_directories(
         ${PROJECT_SOURCE_DIR}/event_data/include
         ${PROJECT_SOURCE_DIR}/nexus_file_reader/include)
 
-file(GLOB TEST_SRC_FILES_GLOB
-        ${PROJECT_SOURCE_DIR}/nexus_producer/test/*.cpp
-        ${PROJECT_SOURCE_DIR}/nexus_file_reader/test/*.cpp
+file(GLOB TEST_SRC_FILES
+        ${PROJECT_SOURCE_DIR}/nexus_producer/test/*Test.cpp
+        ${PROJECT_SOURCE_DIR}/nexus_file_reader/test/*Test.cpp
+        ${PROJECT_SOURCE_DIR}/event_data/test/*Test.cpp
         unitTestRunner.cpp)
-
-set(TEST_SRC_FILES ${TEST_SRC_FILES_GLOB} ${EVENT_TEST_FILES})
 
 add_executable(UnitTests ${TEST_SRC_FILES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,11 +82,12 @@ include_directories(
         ${PROJECT_SOURCE_DIR}/event_data/include
         ${PROJECT_SOURCE_DIR}/nexus_file_reader/include)
 
-file(GLOB TEST_SRC_FILES
+file(GLOB TEST_SRC_FILES_GLOB
         ${PROJECT_SOURCE_DIR}/nexus_producer/test/*.cpp
-        ${PROJECT_SOURCE_DIR}/event_data/test/*.cpp
         ${PROJECT_SOURCE_DIR}/nexus_file_reader/test/*.cpp
         unitTestRunner.cpp)
+
+set(TEST_SRC_FILES ${TEST_SRC_FILES_GLOB} ${EVENT_TEST_FILES})
 
 add_executable(UnitTests ${TEST_SRC_FILES})
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 fixes:
-  - "NeXus-Streamer/::"  # Corrects coverage paths to be relative to repo root
+  - "NeXus-Streamer/::"
 
 comment:
   layout: "header, diff, tree, changes, sunburst"
-require_changes: false
+  require_changes: no
+

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -3,6 +3,7 @@ hdf5/1.10.2-dm1@ess-dmsc/stable
 librdkafka/0.11.3-dm3@ess-dmsc/testing
 gtest/3121b20-dm3@ess-dmsc/stable
 cli11/1.3.0@bincrafters/stable
+google-benchmark/4c2af07-dm2@ess-dmsc/stable
 
 [generators]
 cmake

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -3,7 +3,7 @@ hdf5/1.10.2-dm1@ess-dmsc/stable
 librdkafka/0.11.3-dm3@ess-dmsc/testing
 gtest/3121b20-dm3@ess-dmsc/stable
 cli11/1.3.0@bincrafters/stable
-google-benchmark/4c2af07-dm2@ess-dmsc/stable
+google-benchmark/4c2af07-dm3@ess-dmsc/stable
 
 [generators]
 cmake

--- a/event_data/CMakeLists.txt
+++ b/event_data/CMakeLists.txt
@@ -20,7 +20,7 @@ set( INC_FILES
         include/SampleEnvironmentEventDouble.h
         )
 
-set( TEST_FILES
+set( EVENT_TEST_FILES
         test/EventDataTest.cpp
         test/RunDataTest.cpp
         test/DetectorSpectrumMapDataTest.cpp
@@ -47,7 +47,7 @@ if(UNIX)
 endif()
 
 add_library(eventDataUnitTests
-        ${TEST_FILES})
+        ${EVENT_TEST_FILES})
 target_link_libraries(eventDataUnitTests ${eventData_tests_LINK_LIBRARIES})
 
 ######################

--- a/event_data/CMakeLists.txt
+++ b/event_data/CMakeLists.txt
@@ -20,7 +20,7 @@ set( INC_FILES
         include/SampleEnvironmentEventDouble.h
         )
 
-set( EVENT_TEST_FILES
+set( TEST_FILES
         test/EventDataTest.cpp
         test/RunDataTest.cpp
         test/DetectorSpectrumMapDataTest.cpp
@@ -47,7 +47,7 @@ if(UNIX)
 endif()
 
 add_library(eventDataUnitTests
-        ${EVENT_TEST_FILES})
+        ${TEST_FILES})
 target_link_libraries(eventDataUnitTests ${eventData_tests_LINK_LIBRARIES})
 
 ######################

--- a/event_data/CMakeLists.txt
+++ b/event_data/CMakeLists.txt
@@ -56,3 +56,6 @@ target_link_libraries(eventDataUnitTests ${eventData_tests_LINK_LIBRARIES})
 
 add_executable(benchmark_serialisation test/BenchmarkSerialisation.cpp)
 target_link_libraries(benchmark_serialisation CONAN_PKG::google-benchmark eventdata_lib)
+if(WIN32)
+    target_link_libraries(benchmark_serialisation shlwapi.lib)
+endif(WIN32)

--- a/event_data/CMakeLists.txt
+++ b/event_data/CMakeLists.txt
@@ -49,3 +49,10 @@ endif()
 add_library(eventDataUnitTests
         ${TEST_FILES})
 target_link_libraries(eventDataUnitTests ${eventData_tests_LINK_LIBRARIES})
+
+######################
+## Benchmark        ##
+######################
+
+add_executable(benchmark_serialisation test/BenchmarkSerialisation.cpp)
+target_link_libraries(benchmark_serialisation CONAN_PKG::google-benchmark eventdata_lib)

--- a/event_data/src/EventData.cpp
+++ b/event_data/src/EventData.cpp
@@ -28,18 +28,18 @@ flatbuffers::unique_ptr_t EventData::getBufferPointer(std::string &buffer,
   flatbuffers::FlatBufferBuilder builder;
 
   auto isisDataMessage =
-    CreateISISData(builder, m_period, RunState_RUNNING, m_protonCharge);
+      CreateISISData(builder, m_period, RunState_RUNNING, m_protonCharge);
 
   std::uint8_t *tempTofBuffer;
   std::uint8_t *tempDetIdBuffer;
   auto eventMessage = CreateEventMessage(
-    builder, builder.CreateString("isis_nexus_streamer_for_mantid"),
-    messageID, m_frameTime,
-    builder.CreateUninitializedVector(m_tof.size(), sizeof(uint32_t),
-                                      &tempTofBuffer),
-    builder.CreateUninitializedVector(m_detId.size(), sizeof(uint32_t),
-                                      &tempDetIdBuffer),
-    FacilityData_ISISData, isisDataMessage.Union());
+      builder, builder.CreateString("isis_nexus_streamer_for_mantid"),
+      messageID, m_frameTime,
+      builder.CreateUninitializedVector(m_tof.size(), sizeof(uint32_t),
+                                        &tempTofBuffer),
+      builder.CreateUninitializedVector(m_detId.size(), sizeof(uint32_t),
+                                        &tempDetIdBuffer),
+      FacilityData_ISISData, isisDataMessage.Union());
   std::memcpy(tempTofBuffer, m_tof.data(), m_tof.size() * sizeof(uint32_t));
   std::memcpy(tempDetIdBuffer, m_detId.data(),
               m_detId.size() * sizeof(uint32_t));
@@ -47,7 +47,7 @@ flatbuffers::unique_ptr_t EventData::getBufferPointer(std::string &buffer,
   FinishEventMessageBuffer(builder, eventMessage);
 
   auto bufferpointer =
-    reinterpret_cast<const char *>(builder.GetBufferPointer());
+      reinterpret_cast<const char *>(builder.GetBufferPointer());
   buffer.assign(bufferpointer, bufferpointer + builder.GetSize());
 
   m_bufferSize = builder.GetSize();

--- a/event_data/src/EventData.cpp
+++ b/event_data/src/EventData.cpp
@@ -28,18 +28,26 @@ flatbuffers::unique_ptr_t EventData::getBufferPointer(std::string &buffer,
   flatbuffers::FlatBufferBuilder builder;
 
   auto isisDataMessage =
-      CreateISISData(builder, m_period, RunState_RUNNING, m_protonCharge);
+    CreateISISData(builder, m_period, RunState_RUNNING, m_protonCharge);
 
+  std::uint8_t *tempTofBuffer;
+  std::uint8_t *tempDetIdBuffer;
   auto eventMessage = CreateEventMessage(
-      builder, builder.CreateString("isis_nexus_streamer_for_mantid"),
-      messageID, m_frameTime, builder.CreateVector(m_tof),
-      builder.CreateVector(m_detId), FacilityData_ISISData,
-      isisDataMessage.Union());
+    builder, builder.CreateString("isis_nexus_streamer_for_mantid"),
+    messageID, m_frameTime,
+    builder.CreateUninitializedVector(m_tof.size(), sizeof(uint32_t),
+                                      &tempTofBuffer),
+    builder.CreateUninitializedVector(m_detId.size(), sizeof(uint32_t),
+                                      &tempDetIdBuffer),
+    FacilityData_ISISData, isisDataMessage.Union());
+  std::memcpy(tempTofBuffer, m_tof.data(), m_tof.size() * sizeof(uint32_t));
+  std::memcpy(tempDetIdBuffer, m_detId.data(),
+              m_detId.size() * sizeof(uint32_t));
 
   FinishEventMessageBuffer(builder, eventMessage);
 
   auto bufferpointer =
-      reinterpret_cast<const char *>(builder.GetBufferPointer());
+    reinterpret_cast<const char *>(builder.GetBufferPointer());
   buffer.assign(bufferpointer, bufferpointer + builder.GetSize());
 
   m_bufferSize = builder.GetSize();

--- a/event_data/test/BenchmarkSerialisation.cpp
+++ b/event_data/test/BenchmarkSerialisation.cpp
@@ -1,0 +1,34 @@
+#include "EventData.h"
+#include "benchmark/benchmark.h"
+
+void SerialiseData(benchmark::State &state) {
+  // Generate fake event data of consecutive numbers
+  size_t numberOfFakeEvents = 1000;
+  std::vector<uint32_t> detIds(numberOfFakeEvents);
+  std::vector<uint32_t> tofs(numberOfFakeEvents);
+  int n = 0;
+  std::generate(detIds.begin(), detIds.end(), [n]() mutable { return n++; });
+  std::generate(tofs.begin(), tofs.end(), [n]() mutable { return n++; });
+  float protonCharge = 0.001142;
+  uint64_t frameTime = 41389;
+  uint32_t period = 1;
+
+  // Populate an EventData object
+  auto events = EventData();
+  events.setDetId(detIds);
+  events.setTof(tofs);
+  events.setProtonCharge(protonCharge);
+  events.setFrameTime(frameTime);
+  events.setPeriod(period);
+
+  std::string rawbuf;
+
+  // Benchmark just the serialisation process
+  while (state.KeepRunning()) {
+    events.getBufferPointer(rawbuf, 0);
+  }
+}
+
+BENCHMARK(SerialiseData)->Repetitions(10);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
### Description of work

Improve performance of event message serialisation by avoiding `flatbuffer::createVector()`.
Adds a new `benchmark_serialisation` executable target, which benchmarks the event message serialisation using Google Benchmark.
For a 1000 event message on my machine the old implementation takes 100 microseconds per message and the new implementation takes 3.5 microseconds per message.

### Issue

Closes #17 

### Acceptance Criteria

Unit tests passing should be sufficient.

---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
