### PR TITLE
Set bash -e as build node shell command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,19 +6,19 @@ archive_os = "centos7-gcc6"
 images = [
         'centos7-gcc6': [
                 'name': 'essdmscdm/centos7-gcc6-build-node:2.1.0',
-                'sh'  : '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash'
+                'sh'  : '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash -e'
         ],
         'fedora25'    : [
                 'name': 'essdmscdm/fedora25-build-node:1.0.0',
-                'sh'  : 'sh'
+                'sh'  : 'bash -e'
         ],
         'ubuntu1604'  : [
                 'name': 'essdmscdm/ubuntu16.04-build-node:2.1.0',
-                'sh'  : 'sh'
+                'sh'  : 'bash -e'
         ],
         'ubuntu1710': [
                 'name': 'essdmscdm/ubuntu17.10-build-node:2.0.0',
-                'sh': 'sh'
+                'sh': 'bash -e'
         ]
 ]
 


### PR DESCRIPTION
This makes scripts exit with an error after the first failing command
and does not require using && to continue lines in scripts.

### Description of work

See commit message above.

### Issue

Addresses JIRA DM-923.

### Acceptance Criteria

Jenkins job works as before, but && should no longer be required for scripts to fail after the first failed command.

### Unit Tests

N/A

### Other

N/A

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
