### PR TITLE
Get pulse rate from file for slow mode

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ archive_os = "centos7-gcc6"
 
 images = [
         'centos7-gcc6': [
-                'name': 'essdmscdm/centos7-gcc6-build-node:3.2.0',
+                'name': 'essdmscdm/centos7-build-node:3.2.0',
                 'sh'  : '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash -e'
         ],
         'debian9'    : [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,15 +5,15 @@ archive_os = "centos7-gcc6"
 
 images = [
         'centos7-gcc6': [
-                'name': 'essdmscdm/centos7-gcc6-build-node:2.1.0',
+                'name': 'essdmscdm/centos7-gcc6-build-node:3.2.0',
                 'sh'  : '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash -e'
         ],
         'debian9'    : [
-                'name': 'essdmscdm/debian9-build-node:2.2.0',
+                'name': 'essdmscdm/debian9-build-node:2.3.0',
                 'sh'  : 'bash -e'
         ],
         'ubuntu1804'  : [
-                'name': 'essdmscdm/ubuntu18.04-build-node:1.1.0',
+                'name': 'essdmscdm/ubuntu18.04-build-node:1.2.0',
                 'sh'  : 'bash -e'
         ]
 ]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Options:
   -m,--compression TEXT       Compression option for Kafka messages
   -e,--fake_events_per_pulse INT
                               Generates this number of fake events per pulse instead of publishing real data from file
-  -s,--slow                   Publish data at approx realistic rate (10 pulses per second)
+  -s,--slow                   Publish data at approx realistic rate (detected from file)
   -q,--quiet                  Less chatty on stdout
   -z,--single_run             Publish only a single run (otherwise repeats until interrupted)
   -c,--config_file TEXT       Read configuration from an ini file

--- a/nexus_file_reader/CMakeLists.txt
+++ b/nexus_file_reader/CMakeLists.txt
@@ -4,7 +4,8 @@ set( SRC_FILES
         src/NexusFileReader.cpp)
 
 set( INC_FILES
-        include/NexusFileReader.h)
+        include/NexusFileReader.h
+        include/FileReader.h)
 
 set( TEST_FILES
         test/NexusFileReaderTest.cpp

--- a/nexus_file_reader/include/FileReader.h
+++ b/nexus_file_reader/include/FileReader.h
@@ -9,7 +9,7 @@ using sEEventVector = std::vector<std::shared_ptr<SampleEnvironmentEvent>>;
 
 class FileReader {
 public:
-  virtual ~FileReader() = 0;
+  virtual ~FileReader() = default;
 
   virtual hsize_t getFileSize() = 0;
   virtual uint64_t getTotalEventCount() = 0;

--- a/nexus_file_reader/include/FileReader.h
+++ b/nexus_file_reader/include/FileReader.h
@@ -3,6 +3,7 @@
 #include "../../event_data/include/SampleEnvironmentEvent.h"
 #include <h5cpp/hdf5.hpp>
 #include <unordered_map>
+#include <cmath>
 
 using sEEventVector = std::vector<std::shared_ptr<SampleEnvironmentEvent>>;
 
@@ -25,4 +26,4 @@ public:
   virtual std::unordered_map<hsize_t, sEEventVector> getSEEventMap() = 0;
   virtual int32_t getNumberOfPeriods() = 0;
   virtual uint64_t getRelativeFrameTimeMilliseconds(hsize_t frameNumber) = 0;
-}
+};

--- a/nexus_file_reader/include/FileReader.h
+++ b/nexus_file_reader/include/FileReader.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "../../event_data/include/SampleEnvironmentEvent.h"
+#include <h5cpp/hdf5.hpp>
+#include <unordered_map>
+
+using sEEventVector = std::vector<std::shared_ptr<SampleEnvironmentEvent>>;
+
+class FileReader {
+public:
+  virtual ~FileReader() = 0;
+
+  virtual hsize_t getFileSize() = 0;
+  virtual uint64_t getTotalEventCount() = 0;
+  virtual uint32_t getPeriodNumber() = 0;
+  virtual float getProtonCharge(hsize_t frameNumber) = 0;
+  virtual bool getEventDetIds(std::vector<uint32_t> &detIds,
+                              hsize_t frameNumber) = 0;
+  virtual bool getEventTofs(std::vector<uint32_t> &tofs,
+                            hsize_t frameNumber) = 0;
+  virtual size_t getNumberOfFrames() = 0;
+  virtual hsize_t getNumberOfEventsInFrame(hsize_t frameNumber) = 0;
+  virtual uint64_t getFrameTime(hsize_t frameNumber) = 0;
+  virtual std::string getInstrumentName() = 0;
+  virtual std::unordered_map<hsize_t, sEEventVector> getSEEventMap() = 0;
+  virtual int32_t getNumberOfPeriods() = 0;
+  virtual uint64_t getRelativeFrameTimeMilliseconds(hsize_t frameNumber) = 0;
+}

--- a/nexus_file_reader/include/FileReader.h
+++ b/nexus_file_reader/include/FileReader.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "../../event_data/include/SampleEnvironmentEvent.h"
+#include <cmath>
 #include <h5cpp/hdf5.hpp>
 #include <unordered_map>
-#include <cmath>
 
 using sEEventVector = std::vector<std::shared_ptr<SampleEnvironmentEvent>>;
 

--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -8,7 +8,6 @@
 #include <unordered_map>
 #include <vector>
 
-
 class NexusFileReader : public FileReader {
 public:
   NexusFileReader(hdf5::file::File file, uint64_t runStartTime,
@@ -19,7 +18,8 @@ public:
   uint64_t getTotalEventCount() override;
   uint32_t getPeriodNumber() override;
   float getProtonCharge(hsize_t frameNumber) override;
-  bool getEventDetIds(std::vector<uint32_t> &detIds, hsize_t frameNumber) override;
+  bool getEventDetIds(std::vector<uint32_t> &detIds,
+                      hsize_t frameNumber) override;
   bool getEventTofs(std::vector<uint32_t> &tofs, hsize_t frameNumber) override;
   size_t getNumberOfFrames() override { return m_numberOfFrames; };
   hsize_t getNumberOfEventsInFrame(hsize_t frameNumber) override;

--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -31,6 +31,7 @@ public:
                      hdf5::node::Group &entryGroupOutput);
   void getEventGroup(const hdf5::node::Group &entryGroup,
                      hdf5::node::Group &eventGroupOutput);
+  uint64_t getRelativeFrameTimeMilliseconds(hsize_t frameNumber);
 
 private:
   uint64_t m_runStart;

--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -1,39 +1,39 @@
 #pragma once
 
 #include "../../event_data/include/SampleEnvironmentEvent.h"
+#include "FileReader.h"
 #include <h5cpp/hdf5.hpp>
 #include <memory>
 #include <random>
 #include <unordered_map>
 #include <vector>
 
-using sEEventVector = std::vector<std::shared_ptr<SampleEnvironmentEvent>>;
 
-class NexusFileReader {
+class NexusFileReader : public FileReader {
 public:
   NexusFileReader(hdf5::file::File file, uint64_t runStartTime,
                   int32_t fakeEventsPerPulse,
                   const std::vector<int32_t> &detectorNumbers);
 
-  hsize_t getFileSize();
-  uint64_t getTotalEventCount();
-  uint32_t getPeriodNumber();
-  float getProtonCharge(hsize_t frameNumber);
-  bool getEventDetIds(std::vector<uint32_t> &detIds, hsize_t frameNumber);
-  bool getEventTofs(std::vector<uint32_t> &tofs, hsize_t frameNumber);
-  size_t getNumberOfFrames() { return m_numberOfFrames; };
-  hsize_t getNumberOfEventsInFrame(hsize_t frameNumber);
-  uint64_t getFrameTime(hsize_t frameNumber);
-  std::string getInstrumentName();
-  std::unordered_map<hsize_t, sEEventVector> getSEEventMap();
-  int32_t getNumberOfPeriods();
+  hsize_t getFileSize() override;
+  uint64_t getTotalEventCount() override;
+  uint32_t getPeriodNumber() override;
+  float getProtonCharge(hsize_t frameNumber) override;
+  bool getEventDetIds(std::vector<uint32_t> &detIds, hsize_t frameNumber) override;
+  bool getEventTofs(std::vector<uint32_t> &tofs, hsize_t frameNumber) override;
+  size_t getNumberOfFrames() override { return m_numberOfFrames; };
+  hsize_t getNumberOfEventsInFrame(hsize_t frameNumber) override;
+  uint64_t getFrameTime(hsize_t frameNumber) override;
+  std::string getInstrumentName() override;
+  std::unordered_map<hsize_t, sEEventVector> getSEEventMap() override;
+  int32_t getNumberOfPeriods() override;
+  uint64_t getRelativeFrameTimeMilliseconds(hsize_t frameNumber) override;
+
+private:
   void getEntryGroup(const hdf5::node::Group &rootGroup,
                      hdf5::node::Group &entryGroupOutput);
   void getEventGroup(const hdf5::node::Group &entryGroup,
                      hdf5::node::Group &eventGroupOutput);
-  uint64_t getRelativeFrameTimeMilliseconds(hsize_t frameNumber);
-
-private:
   uint64_t m_runStart;
   size_t findFrameNumberOfTime(float time);
   template <typename T>

--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -2,7 +2,6 @@
 #include "../../event_data/include/SampleEnvironmentEventDouble.h"
 #include "../../event_data/include/SampleEnvironmentEventInt.h"
 #include "../../event_data/include/SampleEnvironmentEventLong.h"
-#include <cmath>
 #include <ctime>
 #include <iomanip>
 #include <iostream>

--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -247,7 +247,7 @@ uint64_t NexusFileReader::getFrameTime(hsize_t frameNumber) {
  * @return - relative time of frame in milliseconds since run start
  */
 uint64_t
-NexusFileReader::getRelativeFrameTimeMilliseconds(hsize_t frameNumber) {
+NexusFileReader::getRelativeFrameTimeMilliseconds(const hsize_t frameNumber) {
   std::string datasetName = "event_time_zero";
 
   auto frameTime =

--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -237,7 +237,7 @@ uint64_t NexusFileReader::getFrameTime(hsize_t frameNumber) {
   auto frameTime =
       getSingleValueFromDataset<double>(m_eventGroup, datasetName, frameNumber);
   auto frameTimeFromOffsetNanoseconds =
-      static_cast<uint64_t>(floor((frameTime * 1e9) + 0.5));
+      static_cast<uint64_t>(round(frameTime * 1e9));
   return m_frameStartOffset + frameTimeFromOffsetNanoseconds;
 }
 
@@ -253,7 +253,8 @@ NexusFileReader::getRelativeFrameTimeMilliseconds(hsize_t frameNumber) {
 
   auto frameTime =
       getSingleValueFromDataset<double>(m_eventGroup, datasetName, frameNumber);
-  return static_cast<uint64_t>(floor((frameTime * 1e3) + 0.5));
+  return static_cast<uint64_t>(
+      round(frameTime * 1e3)); // seconds to milliseconds
 }
 
 template <typename T>

--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -241,6 +241,21 @@ uint64_t NexusFileReader::getFrameTime(hsize_t frameNumber) {
   return m_frameStartOffset + frameTimeFromOffsetNanoseconds;
 }
 
+/**
+ * Gets the frame time relative to the start of run, in milliseconds
+ *
+ * @param frameNumber - find the event index for the start of this frame
+ * @return - relative time of frame in milliseconds since run start
+ */
+uint64_t
+NexusFileReader::getRelativeFrameTimeMilliseconds(hsize_t frameNumber) {
+  std::string datasetName = "event_time_zero";
+
+  auto frameTime =
+      getSingleValueFromDataset<double>(m_eventGroup, datasetName, frameNumber);
+  return static_cast<uint64_t>(floor((frameTime * 1e3) + 0.5));
+}
+
 template <typename T>
 T NexusFileReader::getSingleValueFromDataset(const hdf5::node::Group &group,
                                              const std::string &datasetName,

--- a/nexus_file_reader/test/HDF5FileTestHelpers.cpp
+++ b/nexus_file_reader/test/HDF5FileTestHelpers.cpp
@@ -10,6 +10,15 @@ hdf5::file::File createInMemoryTestFile(const std::string &filename) {
                             hdf5::property::FileCreationList(), fapl);
 }
 
+hdf5::file::File
+createInMemoryTestFileWithEventData(const std::string &filename) {
+  auto file = createInMemoryTestFile(filename);
+  HDF5FileTestHelpers::addNXentryToFile(file);
+  HDF5FileTestHelpers::addNXeventDataToFile(file);
+  HDF5FileTestHelpers::addNXeventDataDatasetsToFile(file);
+  return file;
+}
+
 template <typename T>
 static void write_attribute(hdf5::node::Node &node, const std::string &name,
                             T value) {
@@ -31,25 +40,34 @@ void addNXeventDataToFile(hdf5::file::File &file) {
 }
 
 void addNXeventDataDatasetsToFile(hdf5::file::File &file) {
+  addNXeventDataDatasetsToFile(file, {1}, {2}, {3}, {4});
+}
+
+void addNXeventDataDatasetsToFile(hdf5::file::File &file,
+                                  const std::vector<int64_t> &eventTimeZero,
+                                  const std::vector<int32_t> &eventTimeOffset,
+                                  const std::vector<uint64_t> &eventIndex,
+                                  const std::vector<uint32_t> &eventId) {
   hdf5::node::Group eventGroup = file.root()["entry/detector_1_events"];
-  auto eventTimeZero = eventGroup.create_dataset(
+  auto eventTimeZeroDataset = eventGroup.create_dataset(
       "event_time_zero", hdf5::datatype::create<int64_t>(),
-      hdf5::dataspace::Scalar());
-  eventTimeZero.write(1);
+      hdf5::dataspace::Simple({eventTimeZero.size()}, {eventTimeZero.size()}));
+  eventTimeZeroDataset.write(eventTimeZero);
 
-  auto eventTimeOffset = eventGroup.create_dataset(
+  auto eventTimeOffsetDataset = eventGroup.create_dataset(
       "event_time_offset", hdf5::datatype::create<int32_t>(),
-      hdf5::dataspace::Scalar());
-  eventTimeOffset.write(2);
+      hdf5::dataspace::Simple({eventTimeOffset.size()},
+                              {eventTimeOffset.size()}));
+  eventTimeOffsetDataset.write(eventTimeOffset);
 
-  auto eventIndex = eventGroup.create_dataset(
+  auto eventIndexDataset = eventGroup.create_dataset(
       "event_index", hdf5::datatype::create<uint64_t>(),
-      hdf5::dataspace::Scalar());
-  eventIndex.write(3);
+      hdf5::dataspace::Simple({eventIndex.size()}, {eventIndex.size()}));
+  eventIndexDataset.write(eventIndex);
 
-  auto eventId =
-      eventGroup.create_dataset("event_id", hdf5::datatype::create<uint32_t>(),
-                                hdf5::dataspace::Scalar());
-  eventId.write(4);
+  auto eventIdDataset = eventGroup.create_dataset(
+      "event_id", hdf5::datatype::create<uint32_t>(),
+      hdf5::dataspace::Simple({eventId.size()}, {eventId.size()}));
+  eventIdDataset.write(eventId);
 }
 }

--- a/nexus_file_reader/test/HDF5FileTestHelpers.h
+++ b/nexus_file_reader/test/HDF5FileTestHelpers.h
@@ -7,6 +7,10 @@ namespace HDF5FileTestHelpers {
 /// Creates a file object in memory (does not get written to disk)
 hdf5::file::File createInMemoryTestFile(const std::string &Filename);
 
+/// Creates a file object in memory, containing event data
+hdf5::file::File
+createInMemoryTestFileWithEventData(const std::string &filename);
+
 /// Adds an NXentry group called "entry" to the root of the file
 void addNXentryToFile(hdf5::file::File &file);
 
@@ -15,4 +19,10 @@ void addNXeventDataToFile(hdf5::file::File &file);
 
 /// Adds datasets to event data group in file
 void addNXeventDataDatasetsToFile(hdf5::file::File &file);
+
+void addNXeventDataDatasetsToFile(hdf5::file::File &file,
+                                  const std::vector<int64_t> &eventTimeZero,
+                                  const std::vector<int32_t> &eventTimeOffset,
+                                  const std::vector<uint64_t> &eventIndex,
+                                  const std::vector<uint32_t> &eventId);
 }

--- a/nexus_producer/CMakeLists.txt
+++ b/nexus_producer/CMakeLists.txt
@@ -3,7 +3,8 @@ project(nexus-publisher)
 set( SRC_FILES  src/NexusPublisher.cpp)
 
 set( INC_FILES  include/EventPublisher.h
-                include/NexusPublisher.h)
+                include/NexusPublisher.h
+                include/OptionalArgs.h)
 
 set( TEST_FILES test/NexusPublisherTest.cpp)
 

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -12,6 +12,7 @@
 class NexusPublisher {
 public:
   NexusPublisher(std::shared_ptr<EventPublisher> publisher,
+                 std::shared_ptr<NexusFileReader> fileReader,
                  const OptionalArgs &settings);
   std::vector<std::shared_ptr<EventData>>
   createMessageData(hsize_t frameNumber);
@@ -35,5 +36,4 @@ private:
   std::string m_detSpecMapFilename;
   std::unordered_map<hsize_t, sEEventVector> m_sEEventMap;
   uint64_t m_messageID = 0;
-  uint64_t m_runStartTime;
 };

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -7,14 +7,12 @@
 #include "../../event_data/include/RunData.h"
 #include "../../nexus_file_reader/include/NexusFileReader.h"
 #include "EventPublisher.h"
+#include "OptionalArgs.h"
 
 class NexusPublisher {
 public:
   NexusPublisher(std::shared_ptr<EventPublisher> publisher,
-                 const std::string &brokerAddress,
-                 const std::string &instrumentName, const std::string &filename,
-                 const std::string &detSpecMapFilename, bool quietMode,
-                 int32_t fakeEventsPerPulse = 0);
+                 const OptionalArgs &settings);
   std::vector<std::shared_ptr<EventData>>
   createMessageData(hsize_t frameNumber);
   size_t createAndSendRunMessage(std::string &rawbuf, int runNumber);

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -5,14 +5,14 @@
 #include "../../event_data/include/DetectorSpectrumMapData.h"
 #include "../../event_data/include/EventData.h"
 #include "../../event_data/include/RunData.h"
-#include "../../nexus_file_reader/include/NexusFileReader.h"
+#include "../../nexus_file_reader/include/FileReader.h"
 #include "EventPublisher.h"
 #include "OptionalArgs.h"
 
 class NexusPublisher {
 public:
   NexusPublisher(std::shared_ptr<EventPublisher> publisher,
-                 std::shared_ptr<NexusFileReader> fileReader,
+                 std::shared_ptr<FileReader> fileReader,
                  const OptionalArgs &settings);
   std::vector<std::shared_ptr<EventData>>
   createMessageData(hsize_t frameNumber);
@@ -31,7 +31,7 @@ private:
   void reportProgress(float progress);
 
   std::shared_ptr<EventPublisher> m_publisher;
-  std::shared_ptr<NexusFileReader> m_fileReader;
+  std::shared_ptr<FileReader> m_fileReader;
   bool m_quietMode = false;
   std::string m_detSpecMapFilename;
   std::unordered_map<hsize_t, sEEventVector> m_sEEventMap;

--- a/nexus_producer/include/OptionalArgs.h
+++ b/nexus_producer/include/OptionalArgs.h
@@ -12,5 +12,4 @@ struct OptionalArgs {
   bool quietMode = false;
   bool singleRun = false;
   int32_t fakeEventsPerPulse = 0;
-  float pulseRateInHz = 10;
 };

--- a/nexus_producer/include/OptionalArgs.h
+++ b/nexus_producer/include/OptionalArgs.h
@@ -1,0 +1,14 @@
+#pragma once
+
+struct OptionalArgs {
+    std::string filename;
+    std::string detSpecFilename;
+    std::string broker;
+    std::string instrumentName = "test";
+    std::string compression;
+    bool slow = false;
+    bool quietMode = false;
+    bool singleRun = false;
+    int32_t fakeEventsPerPulse = 0;
+    float pulseRateInHz = 10;
+};

--- a/nexus_producer/include/OptionalArgs.h
+++ b/nexus_producer/include/OptionalArgs.h
@@ -1,14 +1,14 @@
 #pragma once
 
 struct OptionalArgs {
-    std::string filename;
-    std::string detSpecFilename;
-    std::string broker;
-    std::string instrumentName = "test";
-    std::string compression;
-    bool slow = false;
-    bool quietMode = false;
-    bool singleRun = false;
-    int32_t fakeEventsPerPulse = 0;
-    float pulseRateInHz = 10;
+  std::string filename;
+  std::string detSpecFilename;
+  std::string broker;
+  std::string instrumentName = "test";
+  std::string compression;
+  bool slow = false;
+  bool quietMode = false;
+  bool singleRun = false;
+  int32_t fakeEventsPerPulse = 0;
+  float pulseRateInHz = 10;
 };

--- a/nexus_producer/include/OptionalArgs.h
+++ b/nexus_producer/include/OptionalArgs.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 struct OptionalArgs {
   std::string filename;
   std::string detSpecFilename;

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -21,7 +21,7 @@
  * data
  */
 NexusPublisher::NexusPublisher(std::shared_ptr<EventPublisher> publisher,
-                               std::shared_ptr<NexusFileReader> fileReader,
+                               std::shared_ptr<FileReader> fileReader,
                                const OptionalArgs &settings)
     : m_publisher(std::move(publisher)), m_fileReader(std::move(fileReader)),
       m_quietMode(settings.quietMode),

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -21,14 +21,9 @@
  * data
  */
 NexusPublisher::NexusPublisher(std::shared_ptr<EventPublisher> publisher,
-                               const std::string &brokerAddress,
-                               const std::string &instrumentName,
-                               const std::string &filename,
-                               const std::string &detSpecMapFilename,
-                               const bool quietMode,
-                               const int32_t fakeEventsPerPulse)
-    : m_publisher(publisher), m_quietMode(quietMode),
-      m_detSpecMapFilename(detSpecMapFilename) {
+                               const OptionalArgs &settings)
+    : m_publisher(publisher), m_quietMode(settings.quietMode),
+      m_detSpecMapFilename(settings.detSpecFilename) {
   auto now = std::chrono::system_clock::now();
   auto now_c = std::chrono::system_clock::to_time_t(now);
   m_runStartTime = static_cast<uint64_t>(now_c) * 1000000000L;
@@ -37,9 +32,9 @@ NexusPublisher::NexusPublisher(std::shared_ptr<EventPublisher> publisher,
   auto detectorNumbers = detSpecMap.getDetectors();
 
   m_fileReader = std::make_shared<NexusFileReader>(
-      hdf5::file::open(filename), m_runStartTime, fakeEventsPerPulse,
+      hdf5::file::open(settings.filename), m_runStartTime, settings.fakeEventsPerPulse,
       detectorNumbers);
-  publisher->setUp(brokerAddress, instrumentName);
+  publisher->setUp(settings.broker, settings.instrumentName);
   m_sEEventMap = m_fileReader->getSEEventMap();
 }
 

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -21,20 +21,12 @@
  * data
  */
 NexusPublisher::NexusPublisher(std::shared_ptr<EventPublisher> publisher,
+                               std::shared_ptr<NexusFileReader> fileReader,
                                const OptionalArgs &settings)
-    : m_publisher(publisher), m_quietMode(settings.quietMode),
+    : m_publisher(std::move(publisher)), m_fileReader(std::move(fileReader)),
+      m_quietMode(settings.quietMode),
       m_detSpecMapFilename(settings.detSpecFilename) {
-  auto now = std::chrono::system_clock::now();
-  auto now_c = std::chrono::system_clock::to_time_t(now);
-  m_runStartTime = static_cast<uint64_t>(now_c) * 1000000000L;
 
-  auto detSpecMap = DetectorSpectrumMapData(m_detSpecMapFilename);
-  auto detectorNumbers = detSpecMap.getDetectors();
-
-  m_fileReader = std::make_shared<NexusFileReader>(
-      hdf5::file::open(settings.filename), m_runStartTime,
-      settings.fakeEventsPerPulse, detectorNumbers);
-  publisher->setUp(settings.broker, settings.instrumentName);
   m_sEEventMap = m_fileReader->getSEEventMap();
 }
 

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -14,10 +14,12 @@ int main(int argc, char **argv) {
 
   OptionalArgs settings;
 
-  App.add_option("-f,--filename", settings.filename, "Full path of the NeXus file");
+  App.add_option("-f,--filename", settings.filename,
+                 "Full path of the NeXus file");
   App.add_option("-d,--det_spec_map", settings.detSpecFilename,
                  "Full path of the detector-spectrum map");
-  App.add_option("-b,--broker", settings.broker, "Hostname or IP of Kafka broker");
+  App.add_option("-b,--broker", settings.broker,
+                 "Hostname or IP of Kafka broker");
   App.add_option("-i,--instrument", settings.instrumentName,
                  "Used as prefix for topic names");
   App.add_option("-m,--compression", settings.compression,

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -1,11 +1,11 @@
+#include "KafkaEventPublisher.h"
+#include "NexusPublisher.h"
+#include "OptionalArgs.h"
+#include "../../nexus_file_reader/include/NexusFileReader.h"
 #include <CLI/CLI.hpp>
 #include <chrono>
 #include <iostream>
 #include <thread>
-
-#include "KafkaEventPublisher.h"
-#include "NexusPublisher.h"
-#include "OptionalArgs.h"
 
 uint64_t getTimeNowNanosecondsFromEpoch() {
   auto now = std::chrono::system_clock::now();

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -40,10 +40,8 @@ int main(int argc, char **argv) {
   App.add_option("-e,--fake_events_per_pulse", settings.fakeEventsPerPulse,
                  "Generates this number of fake events per pulse instead of "
                  "publishing real data from file");
-  App.add_option("-p,--pulse_rate_hz", settings.pulseRateInHz,
-                 "Specify pulse rate in Hz, default is 10 Hz");
   App.add_flag("-s,--slow", settings.slow,
-               "Publish data at approx realistic rate (10 pulses per second)");
+               "Publish data at approx realistic rate (detected from file)");
   App.add_flag("-q,--quiet", settings.quietMode, "Less chatty on stdout");
   App.add_flag(
       "-z,--single_run", settings.singleRun,

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -1,7 +1,7 @@
+#include "../../nexus_file_reader/include/NexusFileReader.h"
 #include "KafkaEventPublisher.h"
 #include "NexusPublisher.h"
 #include "OptionalArgs.h"
-#include "../../nexus_file_reader/include/NexusFileReader.h"
 #include <CLI/CLI.hpp>
 #include <chrono>
 #include <iostream>

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -94,7 +94,7 @@ TEST_F(NexusPublisherTest, test_stream_data) {
   const int numberOfFrames = 1;
 
   EXPECT_CALL(*publisher.get(), sendEventMessage(_, _)).Times(numberOfFrames);
-  //EXPECT_CALL(*publisher.get(), sendSampleEnvMessage(_, _)).Times(16);
+  // EXPECT_CALL(*publisher.get(), sendSampleEnvMessage(_, _)).Times(16);
   EXPECT_CALL(*publisher.get(), sendRunMessage(_, _))
       .Times(2); // Start and stop messages
   EXPECT_CALL(*publisher.get(), sendDetSpecMessage(_, _)).Times(1);

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -53,7 +53,7 @@ public:
     return settings;
   }
 
-  NexusPublisher createStreamer(bool quiet) {
+  NexusPublisher createStreamer(const bool quiet) {
     const auto settings = createSettings(quiet);
 
     auto publisher = std::make_shared<MockEventPublisher>();

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -94,7 +94,6 @@ TEST_F(NexusPublisherTest, test_stream_data) {
   const int numberOfFrames = 1;
 
   EXPECT_CALL(*publisher.get(), sendEventMessage(_, _)).Times(numberOfFrames);
-  // EXPECT_CALL(*publisher.get(), sendSampleEnvMessage(_, _)).Times(16);
   EXPECT_CALL(*publisher.get(), sendRunMessage(_, _))
       .Times(2); // Start and stop messages
   EXPECT_CALL(*publisher.get(), sendDetSpecMessage(_, _)).Times(1);
@@ -103,6 +102,27 @@ TEST_F(NexusPublisherTest, test_stream_data) {
       std::make_shared<FakeFileReader>();
   NexusPublisher streamer(publisher, fakeFileReader, settings);
   EXPECT_NO_THROW(streamer.streamData(1, false));
+}
+
+TEST_F(NexusPublisherTest, test_data_is_streamed_in_slow_mode) {
+  using ::testing::Sequence;
+
+  const auto settings = createSettings(true);
+
+  auto publisher = std::make_shared<MockEventPublisher>();
+  publisher->setUp(settings.broker, settings.instrumentName);
+
+  const int numberOfFrames = 1;
+
+  EXPECT_CALL(*publisher.get(), sendEventMessage(_, _)).Times(numberOfFrames);
+  EXPECT_CALL(*publisher.get(), sendRunMessage(_, _))
+      .Times(2); // Start and stop messages
+  EXPECT_CALL(*publisher.get(), sendDetSpecMessage(_, _)).Times(1);
+
+  std::shared_ptr<FileReader> fakeFileReader =
+      std::make_shared<FakeFileReader>();
+  NexusPublisher streamer(publisher, fakeFileReader, settings);
+  EXPECT_NO_THROW(streamer.streamData(1, true));
 }
 
 TEST_F(NexusPublisherTest, test_create_run_message_data) {

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -11,7 +11,6 @@ using ::testing::_;
 
 class NexusPublisherTest : public ::testing::Test {
 public:
-
   OptionalArgs createSettings(bool quiet) {
     extern std::string testDataPath;
 
@@ -28,7 +27,8 @@ public:
     const auto settings = createSettings(quiet);
 
     auto publisher = std::make_shared<MockEventPublisher>();
-    EXPECT_CALL(*publisher.get(), setUp(settings.broker, settings.instrumentName))
+    EXPECT_CALL(*publisher.get(),
+                setUp(settings.broker, settings.instrumentName))
         .Times(AtLeast(1));
 
     NexusPublisher streamer(publisher, settings);


### PR DESCRIPTION
### Description of work

When in `--slow` mode, uses frame time dataset from `NXevent_data` to dictate how long the publisher waits between publishing the data for each pulse. This should work even if the time between pulses is not constant (for example at ISIS where some pulses are sent to the other target).

Now uses a struct for the optional args as many are passed to the publisher class.

### Issue

Closes #35

### Unit Tests

Added a unit test to `NexusFileReaderTest` for getting the relative frame time from file.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
