### PR TITLE
Rolling back to using CreateVector in the flatbuffers builder …

### DIFF
--- a/event_data/src/EventData.cpp
+++ b/event_data/src/EventData.cpp
@@ -33,15 +33,8 @@ flatbuffers::unique_ptr_t EventData::getBufferPointer(std::string &buffer,
   auto isisDataMessage =
       CreateISISData(builder, m_period, RunState_RUNNING, m_protonCharge);
 
-  std::uint8_t *tempTofBuffer;
-  std::uint8_t *tempDetIdBuffer;
-  auto tofData = builder.CreateUninitializedVector(
-      m_tof.size(), sizeof(uint32_t), &tempTofBuffer);
-  auto detIDData = builder.CreateUninitializedVector(
-      m_detId.size(), sizeof(uint32_t), &tempDetIdBuffer);
-  std::memcpy(tempTofBuffer, m_tof.data(), m_tof.size() * sizeof(uint32_t));
-  std::memcpy(tempDetIdBuffer, m_detId.data(),
-              m_detId.size() * sizeof(uint32_t));
+  auto detIDData = builder.CreateVector(m_detId);
+  auto tofData = builder.CreateVector(m_tof);
 
   auto sourceStr = builder.CreateString("NeXus-Streamer");
 


### PR DESCRIPTION
### Description of work

Changing the flatbuffers builder step to use the built in CreateVector function as for some reason the memcpy was missing out the first frame and setting all detector IDs in the event data to 0.

### Issue

Closes #37 

### Acceptance Criteria

No functionality change besides not using a buffer so may be slower than before. 

### Unit Tests

No unit tests modified. 
---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
