### PR TITLE
Use conan-generated run env script when launching in container

### DIFF
--- a/docker/docker-start.sh
+++ b/docker/docker-start.sh
@@ -18,4 +18,5 @@ then
    exit 1
 fi
 
+source /nexus_streamer/activate_run.sh
 /nexus_streamer/bin/nexus-streamer -c ${CONFIG_FILE}


### PR DESCRIPTION
This gets around the problem in #39 at least when using container.