### PR TITLE
Truncate SANS2D det-spec map to only real detector pixels

### DIFF
--- a/data/spectrum_gastubes_01.dat
+++ b/data/spectrum_gastubes_01.dat
@@ -1,5 +1,5 @@
 Number_of_entries
-           245768
+           122888
 Detector  Spectrum
        1         1
        2         2

--- a/event_data/test/DetectorSpectrumMapDataTest.cpp
+++ b/event_data/test/DetectorSpectrumMapDataTest.cpp
@@ -20,24 +20,24 @@ TEST(DetectorSpectrumMapDataTest, read_detector_spectrum_map_detectors) {
   extern std::string testDataPath;
   auto detSpecMap =
       DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat");
-  EXPECT_EQ(245768, detSpecMap.getNumberOfEntries());
+  EXPECT_EQ(122888, detSpecMap.getNumberOfEntries());
 
   auto detectors = detSpecMap.getDetectors();
   EXPECT_EQ(1, detectors[0]);
   EXPECT_EQ(1100000, detectors[8]);
-  EXPECT_EQ(4523511, detectors[245767]);
+  EXPECT_EQ(2523511, detectors[122887]);
 }
 
 TEST(DetectorSpectrumMapDataTest, read_detector_spectrum_map_spectra) {
   extern std::string testDataPath;
   auto detSpecMap =
       DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat");
-  EXPECT_EQ(245768, detSpecMap.getNumberOfEntries());
+  EXPECT_EQ(122888, detSpecMap.getNumberOfEntries());
 
   auto spectra = detSpecMap.getSpectra();
   EXPECT_EQ(1, spectra[0]);
   EXPECT_EQ(9, spectra[8]);
-  EXPECT_EQ(245768, spectra[245767]);
+  EXPECT_EQ(122888, spectra[122887]);
 }
 
 TEST(DetectorSpectrumMapDataTest, create_message_buffer) {
@@ -51,15 +51,15 @@ TEST(DetectorSpectrumMapDataTest, create_message_buffer) {
   auto receivedMapData = DetectorSpectrumMapData();
   EXPECT_NO_THROW(receivedMapData.decodeMessage(
       reinterpret_cast<const uint8_t *>(rawbuf.c_str())));
-  EXPECT_EQ(245768, receivedMapData.getNumberOfEntries());
+  EXPECT_EQ(122888, receivedMapData.getNumberOfEntries());
 
   auto detectors = receivedMapData.getDetectors();
   EXPECT_EQ(1, detectors[0]);
   EXPECT_EQ(1100000, detectors[8]);
-  EXPECT_EQ(4523511, detectors[245767]);
+  EXPECT_EQ(2523511, detectors[122887]);
 
   auto spectra = receivedMapData.getSpectra();
   EXPECT_EQ(1, spectra[0]);
   EXPECT_EQ(9, spectra[8]);
-  EXPECT_EQ(245768, spectra[245767]);
+  EXPECT_EQ(122888, spectra[122887]);
 }

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -96,5 +96,5 @@ TEST_F(NexusPublisherTest, test_create_det_spec_map_message_data) {
   auto receivedData = DetectorSpectrumMapData();
   EXPECT_NO_THROW(receivedData.decodeMessage(
       reinterpret_cast<const uint8_t *>(rawbuf.c_str())));
-  EXPECT_EQ(245768, receivedData.getNumberOfEntries());
+  EXPECT_EQ(122888, receivedData.getNumberOfEntries());
 }


### PR DESCRIPTION
### Description of work

Remove the spectra numbers associated with the integration card for SANS2D. This is causing problems downstream in the data pipeline as Mantid doesn't know not to generate a load of extra histogram bins for these spectra.

### Issue

Closes #42

### Acceptance Criteria

*List the changes in functionality or code that the reviewer needs to review.*

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
