### PR TITLE
Adding option to disable sending the detector spectrum map

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ nexus-streamer <OPTIONS>
 Options:
   -h,--help                   Print this help message and exit
   -f,--filename FILE REQUIRED Full path of the NeXus file
-  -d,--det_spec_map FILE REQUIRED
-                              Full path of the detector-spectrum map
+  -d,--det_spec_map FILE      Full path of the detector-spectrum map
   -b,--broker TEXT REQUIRED   Hostname or IP of Kafka broker
   -i,--instrument TEXT REQUIRED
                               Used as prefix for topic names
   -m,--compression TEXT       Compression option for Kafka messages
   -e,--fake_events_per_pulse INT
                               Generates this number of fake events per pulse instead of publishing real data from file
+  -x,--disable-map INT INT    Use MIN and MAX detector numbers in inclusive range instead of using a det-spec map file
   -s,--slow                   Publish data at approx realistic rate (detected from file)
   -q,--quiet                  Less chatty on stdout
   -z,--single_run             Publish only a single run (otherwise repeats until interrupted)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Options:
   -z,--single_run             Publish only a single run (otherwise repeats until interrupted)
   -c,--config_file TEXT       Read configuration from an ini file
 ```
-Arguments not marked with `REQUIRED` are Optional. 
+Arguments not marked with `REQUIRED` are Optional.
+A detector-spectrum map must be provided for use with Mantid. 
 
 Usage example:
 ```

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -20,7 +20,7 @@ public:
   size_t createAndSendDetSpecMessage(std::string &rawbuf);
   std::shared_ptr<RunData> createRunMessageData(int runNumber);
   std::shared_ptr<DetectorSpectrumMapData> createDetSpecMessageData();
-  void streamData(int runNumber, bool slow);
+  void streamData(int runNumber, bool slow, std::pair<int32_t, int32_t> minMaxDetNums);
 
 private:
   int64_t getTimeNowInNanoseconds();

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -20,7 +20,8 @@ public:
   size_t createAndSendDetSpecMessage(std::string &rawbuf);
   std::shared_ptr<RunData> createRunMessageData(int runNumber);
   std::shared_ptr<DetectorSpectrumMapData> createDetSpecMessageData();
-  void streamData(int runNumber, bool slow, std::pair<int32_t, int32_t> minMaxDetNums);
+  void streamData(int runNumber, bool slow,
+                  std::pair<int32_t, int32_t> minMaxDetNums);
 
 private:
   int64_t getTimeNowInNanoseconds();

--- a/nexus_producer/include/OptionalArgs.h
+++ b/nexus_producer/include/OptionalArgs.h
@@ -3,7 +3,7 @@
 #include <string>
 
 struct OptionalArgs {
-  std::pair<int32_t, int32_t> minMaxDetectorNums;
+  std::pair<int32_t, int32_t> minMaxDetectorNums = {0, 0};
   std::string filename;
   std::string detSpecFilename;
   std::string broker;

--- a/nexus_producer/include/OptionalArgs.h
+++ b/nexus_producer/include/OptionalArgs.h
@@ -8,6 +8,7 @@ struct OptionalArgs {
   std::string broker;
   std::string instrumentName = "test";
   std::string compression;
+  bool disableDetSpecMap = false;
   bool slow = false;
   bool quietMode = false;
   bool singleRun = false;

--- a/nexus_producer/include/OptionalArgs.h
+++ b/nexus_producer/include/OptionalArgs.h
@@ -3,12 +3,12 @@
 #include <string>
 
 struct OptionalArgs {
+  std::pair<int32_t, int32_t> minMaxDetectorNums;
   std::string filename;
   std::string detSpecFilename;
   std::string broker;
   std::string instrumentName = "test";
   std::string compression;
-  bool disableDetSpecMap = false;
   bool slow = false;
   bool quietMode = false;
   bool singleRun = false;

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -93,7 +93,8 @@ NexusPublisher::createDetSpecMessageData() {
 /**
  * Start streaming all the data from the file
  */
-void NexusPublisher::streamData(int runNumber, bool slow, std::pair<int32_t, int32_t> minMaxDetNums) {
+void NexusPublisher::streamData(int runNumber, bool slow,
+                                std::pair<int32_t, int32_t> minMaxDetNums) {
   std::string rawbuf;
   std::string sampleEnvBuf;
   // frame numbers run from 0 to numberOfFrames-1

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -101,6 +101,7 @@ void NexusPublisher::streamData(int runNumber, bool slow) {
   const auto numberOfFrames = m_fileReader->getNumberOfFrames();
 
   totalBytesSent += createAndSendRunMessage(rawbuf, runNumber);
+  // TODO: disable sending this if flag exists
   totalBytesSent += createAndSendDetSpecMessage(rawbuf);
 
   uint64_t lastFrameTime = 0;

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -93,7 +93,7 @@ NexusPublisher::createDetSpecMessageData() {
 /**
  * Start streaming all the data from the file
  */
-void NexusPublisher::streamData(int runNumber, bool slow) {
+void NexusPublisher::streamData(int runNumber, bool slow, std::pair<int32_t, int32_t> minMaxDetNums) {
   std::string rawbuf;
   std::string sampleEnvBuf;
   // frame numbers run from 0 to numberOfFrames-1
@@ -101,8 +101,9 @@ void NexusPublisher::streamData(int runNumber, bool slow) {
   const auto numberOfFrames = m_fileReader->getNumberOfFrames();
 
   totalBytesSent += createAndSendRunMessage(rawbuf, runNumber);
-  // TODO: disable sending this if flag exists
-  totalBytesSent += createAndSendDetSpecMessage(rawbuf);
+  if (minMaxDetNums.first == 0 && minMaxDetNums.second == 0) {
+    totalBytesSent += createAndSendDetSpecMessage(rawbuf);
+  }
 
   uint64_t lastFrameTime = 0;
   for (size_t frameNumber = 0; frameNumber < numberOfFrames; frameNumber++) {

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -97,10 +97,10 @@ int main(int argc, char **argv) {
 
   // Publish the same data repeatedly, with incrementing run numbers
   if (settings.singleRun) {
-    streamer.streamData(runNumber, settings.slow);
+    streamer.streamData(runNumber, settings.slow, settings.minMaxDetectorNums);
   } else {
     while (true) {
-      streamer.streamData(runNumber, settings.slow);
+      streamer.streamData(runNumber, settings.slow, settings.minMaxDetectorNums);
       std::this_thread::sleep_for(std::chrono::seconds(2));
       runNumber++;
     }

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -33,8 +33,7 @@ int main(int argc, char **argv) {
       ->required();
   App.add_option("-d,--det_spec_map", settings.detSpecFilename,
                  "Full path of the detector-spectrum map")
-      ->check(CLI::ExistingFile)
-      ->required();
+      ->check(CLI::ExistingFile);
   App.add_option("-b,--broker", settings.broker,
                  "Hostname or IP of Kafka broker")
       ->required();
@@ -46,6 +45,8 @@ int main(int argc, char **argv) {
   App.add_option("-e,--fake_events_per_pulse", settings.fakeEventsPerPulse,
                  "Generates this number of fake events per pulse instead of "
                  "publishing real data from file");
+  App.add_flag("-x,--disable-map", settings.disableDetSpecMap,
+               "Disable sending detector-spectrum map");
   App.add_flag("-s,--slow", settings.slow,
                "Publish data at approx realistic rate (detected from file)");
   App.add_flag("-q,--quiet", settings.quietMode, "Less chatty on stdout");

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -100,7 +100,8 @@ int main(int argc, char **argv) {
     streamer.streamData(runNumber, settings.slow, settings.minMaxDetectorNums);
   } else {
     while (true) {
-      streamer.streamData(runNumber, settings.slow, settings.minMaxDetectorNums);
+      streamer.streamData(runNumber, settings.slow,
+                          settings.minMaxDetectorNums);
       std::this_thread::sleep_for(std::chrono::seconds(2));
       runNumber++;
     }

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -124,7 +124,7 @@ TEST_F(NexusPublisherTest, test_det_spec_not_sent_when_pair_is_empty) {
       std::make_shared<FakeFileReader>();
   NexusPublisher streamer(publisher, fakeFileReader, settings);
   EXPECT_NO_THROW(
-      streamer.streamData(1, false, std::make_pair<int32_t, int32_t>(1, 256)));
+      streamer.streamData(1, false, std::make_pair<int32_t, int32_t>(1, 2)));
 }
 
 TEST_F(NexusPublisherTest, test_data_is_streamed_in_slow_mode) {

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -101,7 +101,30 @@ TEST_F(NexusPublisherTest, test_stream_data) {
   std::shared_ptr<FileReader> fakeFileReader =
       std::make_shared<FakeFileReader>();
   NexusPublisher streamer(publisher, fakeFileReader, settings);
-  EXPECT_NO_THROW(streamer.streamData(1, false));
+  EXPECT_NO_THROW(
+      streamer.streamData(1, false, std::make_pair<int32_t, int32_t>(0, 0)));
+}
+
+TEST_F(NexusPublisherTest, test_det_spec_not_sent_when_pair_is_empty) {
+  using ::testing::Sequence;
+
+  const auto settings = createSettings(true);
+
+  auto publisher = std::make_shared<MockEventPublisher>();
+  publisher->setUp(settings.broker, settings.instrumentName);
+
+  const int numberOfFrames = 1;
+
+  EXPECT_CALL(*publisher.get(), sendEventMessage(_, _)).Times(numberOfFrames);
+  EXPECT_CALL(*publisher.get(), sendRunMessage(_, _))
+      .Times(2); // Start and stop messages
+  EXPECT_CALL(*publisher.get(), sendDetSpecMessage(_, _)).Times(0);
+
+  std::shared_ptr<FileReader> fakeFileReader =
+      std::make_shared<FakeFileReader>();
+  NexusPublisher streamer(publisher, fakeFileReader, settings);
+  EXPECT_NO_THROW(
+      streamer.streamData(1, false, std::make_pair<int32_t, int32_t>(1, 256)));
 }
 
 TEST_F(NexusPublisherTest, test_data_is_streamed_in_slow_mode) {
@@ -122,7 +145,8 @@ TEST_F(NexusPublisherTest, test_data_is_streamed_in_slow_mode) {
   std::shared_ptr<FileReader> fakeFileReader =
       std::make_shared<FakeFileReader>();
   NexusPublisher streamer(publisher, fakeFileReader, settings);
-  EXPECT_NO_THROW(streamer.streamData(1, true));
+  EXPECT_NO_THROW(
+      streamer.streamData(1, false, std::make_pair<int32_t, int32_t>(0, 0)));
 }
 
 TEST_F(NexusPublisherTest, test_create_run_message_data) {


### PR DESCRIPTION
### Description of work

Detector IDs are given by `-x` or `--disable-map` in `VALUE VALUE` format with the minimum and maximum ID passed respectively. 

### Issue

Closes #70 

### Acceptance Criteria

Tests still pass and det spec maps are not sent when the flag is given. detector IDs should also only be in the range between the minimum and maximum set when using fake mode. 

### Unit Tests

Added a test to check that `sendDetSpecMessage()` is not called when a det spec map file is not given 
Modified tests to test that when the pair to disable detector spectrum map is empty the detector spectrum map still gets sent. 

### Other

N/A

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
