### PR TITLE
Using Finish method to add file identifier to Det-spec-maps

### DIFF
--- a/event_data/src/DetectorSpectrumMapData.cpp
+++ b/event_data/src/DetectorSpectrumMapData.cpp
@@ -61,13 +61,12 @@ DetectorSpectrumMapData::getBufferPointer(std::string &buffer) {
   auto messageFlatbuf = CreateSpectraDetectorMapping(
       builder, builder.CreateVector(m_spectra),
       builder.CreateVector(m_detectors), m_numberOfEntries);
-  builder.Finish(messageFlatbuf);
+  FinishSpectraDetectorMappingBuffer(builder, messageFlatbuf);
 
   auto bufferpointer =
       reinterpret_cast<const char *>(builder.GetBufferPointer());
   buffer.assign(bufferpointer, bufferpointer + builder.GetSize());
 
   m_bufferSize = builder.GetSize();
-
   return builder.ReleaseBufferPointer();
 }


### PR DESCRIPTION
### Description of work

Setting the detSpecMap file id by using `FinishSpectraDetectorMappingBuffer` instead of `builder.Finish()`
 
Have tested this with KafkaCow and it seems to solve the problem :+1: 

### Issue

Closes #69 

### Acceptance Criteria

Now adds the file identifier to the Flatbuffers object for detector spectrum maps. 

### Unit Tests

None modified

### Other

N/A

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
