### PR TITLE
Support multiple event data groups

### DIFF
--- a/nexus_file_reader/include/FileReader.h
+++ b/nexus_file_reader/include/FileReader.h
@@ -35,4 +35,5 @@ public:
   virtual int32_t getNumberOfPeriods() = 0;
   virtual uint64_t getRelativeFrameTimeMilliseconds(hsize_t frameNumber) = 0;
   virtual bool isISISFile() = 0;
+  virtual uint64_t getTotalEventsInGroup(size_t eventGroupNumber) = 0;
 };

--- a/nexus_file_reader/include/FileReader.h
+++ b/nexus_file_reader/include/FileReader.h
@@ -1,3 +1,5 @@
+#include <utility>
+
 #pragma once
 
 #include "../../event_data/include/SampleEnvironmentEvent.h"
@@ -7,6 +9,13 @@
 
 using sEEventVector = std::vector<std::shared_ptr<SampleEnvironmentEvent>>;
 
+struct EventDataFrame {
+  EventDataFrame(std::vector<uint32_t> detIDs, std::vector<uint32_t> tofs)
+      : detectorIDs(std::move(detIDs)), timeOfFlights(std::move(tofs)) {}
+  std::vector<uint32_t> detectorIDs;
+  std::vector<uint32_t> timeOfFlights;
+};
+
 class FileReader {
 public:
   virtual ~FileReader() = default;
@@ -15,10 +24,11 @@ public:
   virtual uint64_t getTotalEventCount() = 0;
   virtual uint32_t getPeriodNumber() = 0;
   virtual float getProtonCharge(hsize_t frameNumber) = 0;
-  virtual bool getEventDetIds(std::vector<uint32_t> &detIds, hsize_t frameNumber, size_t eventGroupNumber) = 0;
-  virtual bool getEventTofs(std::vector<uint32_t> &tofs, hsize_t frameNumber, size_t eventGroupNumber) = 0;
+  virtual bool getEventData(std::vector<EventDataFrame> &eventData,
+                            hsize_t frameNumber) = 0;
   virtual size_t getNumberOfFrames() = 0;
-  virtual hsize_t getNumberOfEventsInFrame(hsize_t frameNumber, size_t eventGroupNumber) = 0;
+  virtual hsize_t getNumberOfEventsInFrame(hsize_t frameNumber,
+                                           size_t eventGroupNumber) = 0;
   virtual uint64_t getFrameTime(hsize_t frameNumber) = 0;
   virtual std::string getInstrumentName() = 0;
   virtual std::unordered_map<hsize_t, sEEventVector> getSEEventMap() = 0;

--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -9,6 +9,9 @@
 #include <unordered_map>
 #include <vector>
 
+void checkEventDataGroupsHaveConsistentFrames(
+    std::vector<hdf5::node::Group> const &eventGroups);
+
 class NexusFileReader : public FileReader {
 public:
   NexusFileReader(hdf5::file::File file, uint64_t runStartTime,
@@ -19,8 +22,8 @@ public:
   uint64_t getTotalEventCount() override;
   uint32_t getPeriodNumber() override;
   float getProtonCharge(hsize_t frameNumber) override;
-  virtual bool getEventData(std::vector<EventDataFrame> &eventData,
-                            hsize_t frameNumber) override;
+  bool getEventData(std::vector<EventDataFrame> &eventData,
+                    hsize_t frameNumber) override;
   size_t getNumberOfFrames() override { return m_numberOfFrames; };
   hsize_t getNumberOfEventsInFrame(hsize_t frameNumber,
                                    size_t eventGroupNumber) override;
@@ -30,6 +33,7 @@ public:
   int32_t getNumberOfPeriods() override;
   uint64_t getRelativeFrameTimeMilliseconds(hsize_t frameNumber) override;
   bool isISISFile() override;
+  uint64_t getTotalEventsInGroup(size_t eventGroupNumber) override;
 
 private:
   bool getEventDetIds(std::vector<uint32_t> &detIds, hsize_t frameNumber,

--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -19,10 +19,8 @@ public:
   uint64_t getTotalEventCount() override;
   uint32_t getPeriodNumber() override;
   float getProtonCharge(hsize_t frameNumber) override;
-  bool getEventDetIds(std::vector<uint32_t> &detIds, hsize_t frameNumber,
-                      size_t eventGroupNumber) override;
-  bool getEventTofs(std::vector<uint32_t> &tofs, hsize_t frameNumber,
-                    size_t eventGroupNumber) override;
+  virtual bool getEventData(std::vector<EventDataFrame> &eventData,
+                            hsize_t frameNumber) override;
   size_t getNumberOfFrames() override { return m_numberOfFrames; };
   hsize_t getNumberOfEventsInFrame(hsize_t frameNumber,
                                    size_t eventGroupNumber) override;
@@ -34,6 +32,10 @@ public:
   bool isISISFile() override;
 
 private:
+  bool getEventDetIds(std::vector<uint32_t> &detIds, hsize_t frameNumber,
+                      size_t eventGroupNumber);
+  bool getEventTofs(std::vector<uint32_t> &tofs, hsize_t frameNumber,
+                    size_t eventGroupNumber);
   void getEntryGroup(const hdf5::node::Group &rootGroup,
                      hdf5::node::Group &entryGroupOutput);
   void getEventGroups(const hdf5::node::Group &entryGroup,

--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -9,9 +9,6 @@
 #include <unordered_map>
 #include <vector>
 
-void checkEventDataGroupsHaveConsistentFrames(
-    std::vector<hdf5::node::Group> const &eventGroups);
-
 class NexusFileReader : public FileReader {
 public:
   NexusFileReader(hdf5::file::File file, uint64_t runStartTime,

--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -18,7 +18,6 @@ std::vector<uint64_t> secondsToNanoseconds(std::vector<double> const &seconds) {
                  });
   return nanoseconds;
 }
-}
 
 /**
  * We can only currently deal with multiple NXevent_data groups if they contain
@@ -48,6 +47,7 @@ void checkEventDataGroupsHaveConsistentFrames(
       }
     }
   }
+}
 }
 
 /**

--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -430,11 +430,11 @@ bool NexusFileReader::getEventDetIds(std::vector<uint32_t> &detIds,
   auto numberOfEventsInFrame =
       getNumberOfEventsInFrame(frameNumber, eventGroupNumber);
 
-  hsize_t count = numberOfEventsInFrame;
   hsize_t offset = getFrameStart(frameNumber, eventGroupNumber);
-  detIds.resize(count);
+  detIds.resize(numberOfEventsInFrame);
 
-  auto slab = hdf5::dataspace::Hyperslab({offset}, {count}, {1});
+  auto slab =
+      hdf5::dataspace::Hyperslab({offset}, {numberOfEventsInFrame}, {1});
 
   dataset.read(detIds, slab);
 

--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -418,6 +418,24 @@ bool NexusFileReader::getEventTofs(std::vector<uint32_t> &tofs,
   return true;
 }
 
+bool NexusFileReader::getEventData(std::vector<EventDataFrame> &eventData,
+                                   hsize_t frameNumber) {
+  std::vector<uint32_t> detIDs;
+  std::vector<uint32_t> tofs;
+  bool thereIsDataInRequestedFrame = false;
+  for (size_t eventGroupNumber = 0; eventGroupNumber < m_eventGroups.size();
+       ++eventGroupNumber) {
+    if (getEventDetIds(detIDs, frameNumber, eventGroupNumber) &&
+        getEventTofs(tofs, frameNumber, eventGroupNumber)) {
+      eventData.emplace_back(detIDs, tofs);
+      thereIsDataInRequestedFrame = true;
+    } else {
+      thereIsDataInRequestedFrame = false;
+    }
+  }
+  return thereIsDataInRequestedFrame;
+}
+
 bool NexusFileReader::isISISFile() { return m_isisFile; }
 
 /**

--- a/nexus_file_reader/test/HDF5FileTestHelpers.cpp
+++ b/nexus_file_reader/test/HDF5FileTestHelpers.cpp
@@ -33,10 +33,10 @@ void addNXentryToFile(hdf5::file::File &file, const std::string &entryName) {
   write_attribute<std::string>(entryGroup, "NX_class", "NXentry");
 }
 
-void addNXeventDataToFile(hdf5::file::File &file,
-                          const std::string &entryName) {
+void addNXeventDataToFile(hdf5::file::File &file, const std::string &entryName,
+                          const std::string &groupName) {
   hdf5::node::Group entryGroup = file.root()[entryName];
-  auto eventGroup = entryGroup.create_group("detector_1_events");
+  auto eventGroup = entryGroup.create_group(groupName);
   write_attribute<std::string>(eventGroup, "NX_class", "NXevent_data");
 }
 
@@ -50,8 +50,9 @@ void addNXeventDataDatasetsToFile(hdf5::file::File &file,
                                   const std::vector<int32_t> &eventTimeOffset,
                                   const std::vector<uint64_t> &eventIndex,
                                   const std::vector<uint32_t> &eventId,
-                                  const std::string &entryName) {
-  hdf5::node::Group eventGroup = file.root()[entryName + "/detector_1_events"];
+                                  const std::string &entryName,
+                                  const std::string &groupName) {
+  hdf5::node::Group eventGroup = file.root()[entryName + "/" + groupName];
   auto eventTimeZeroDataset = eventGroup.create_dataset(
       "event_time_zero", hdf5::datatype::create<int64_t>(),
       hdf5::dataspace::Simple({eventTimeZero.size()}, {eventTimeZero.size()}));

--- a/nexus_file_reader/test/HDF5FileTestHelpers.h
+++ b/nexus_file_reader/test/HDF5FileTestHelpers.h
@@ -17,18 +17,20 @@ void addNXentryToFile(hdf5::file::File &file,
 
 /// Adds an NXevent_data group called "detector_1_events" to the entry group
 void addNXeventDataToFile(hdf5::file::File &file,
-                          const std::string &entryName = "entry");
+                          const std::string &entryName = "entry",
+                          const std::string &groupName = "detector_1_events");
 
 /// Adds datasets to event data group in file
 void addNXeventDataDatasetsToFile(hdf5::file::File &file,
                                   const std::string &entryName = "entry");
 
-void addNXeventDataDatasetsToFile(hdf5::file::File &file,
-                                  const std::vector<int64_t> &eventTimeZero,
-                                  const std::vector<int32_t> &eventTimeOffset,
-                                  const std::vector<uint64_t> &eventIndex,
-                                  const std::vector<uint32_t> &eventId,
-                                  const std::string &entryName = "entry");
+void addNXeventDataDatasetsToFile(
+    hdf5::file::File &file, const std::vector<int64_t> &eventTimeZero,
+    const std::vector<int32_t> &eventTimeOffset,
+    const std::vector<uint64_t> &eventIndex,
+    const std::vector<uint32_t> &eventId,
+    const std::string &entryName = "entry",
+    const std::string &groupName = "detector_1_events");
 
 void addVMSCompatGroupToFile(hdf5::file::File &file);
 }

--- a/nexus_file_reader/test/NexusFileReaderTest.cpp
+++ b/nexus_file_reader/test/NexusFileReaderTest.cpp
@@ -235,8 +235,9 @@ TEST(NexusFileReaderTest,
   HDF5FileTestHelpers::addNXeventDataToFile(file, "raw_data_1");
   HDF5FileTestHelpers::addNXeventDataDatasetsToFile(file, "raw_data_1");
   auto fileReader = NexusFileReader(file, 0, 0, {0});
-  // No "isis_vms_compat" group in file, so should assume not an ISIS file
-  EXPECT_FALSE(fileReader.isISISFile());
+  EXPECT_FALSE(fileReader.isISISFile()) << "The is no \"isis_vms_compat\" "
+                                           "group in file, so expect to detect "
+                                           "that it is not an ISIS file";
 }
 
 TEST(NexusFileReaderTest,

--- a/nexus_file_reader/test/NexusFileReaderTest.cpp
+++ b/nexus_file_reader/test/NexusFileReaderTest.cpp
@@ -94,19 +94,19 @@ TEST(NexusFileReaderTest, nexus_read_number_frames) {
 TEST(NexusFileReaderTest, get_detIds_first_frame) {
   auto fileReader = NexusFileReader(
       hdf5::file::open(testDataPath + "SANS_test.nxs"), 0, 0, {0});
-  std::vector<uint32_t> detIds;
-  EXPECT_TRUE(fileReader.getEventDetIds(detIds, 0, 0));
-  EXPECT_EQ(99406, detIds[0]);
-  EXPECT_EQ(87829, detIds[150]);
+  std::vector<EventDataFrame> eventData;
+  EXPECT_TRUE(fileReader.getEventData(eventData, 0));
+  EXPECT_EQ(99406, eventData[0].detectorIDs[0]);
+  EXPECT_EQ(87829, eventData[0].detectorIDs[150]);
 }
 
 TEST(NexusFileReaderTest, get_event_tofs) {
   auto fileReader = NexusFileReader(
       hdf5::file::open(testDataPath + "SANS_test.nxs"), 0, 0, {0});
-  std::vector<uint32_t> eventTofs;
-  EXPECT_TRUE(fileReader.getEventTofs(eventTofs, 0, 0));
-  EXPECT_EQ(11660506, eventTofs[0]);
-  EXPECT_EQ(46247304, eventTofs[150]);
+  std::vector<EventDataFrame> eventData;
+  EXPECT_TRUE(fileReader.getEventData(eventData, 0));
+  EXPECT_EQ(11660506, eventData[0].timeOfFlights[0]);
+  EXPECT_EQ(46247304, eventData[0].timeOfFlights[150]);
 }
 
 TEST(NexusFileReaderTest,
@@ -115,9 +115,9 @@ TEST(NexusFileReaderTest,
   auto fileReader =
       NexusFileReader(hdf5::file::open(testDataPath + "SANS_test.nxs"), 0,
                       numberOfFakeEventsPerPulse, {0});
-  std::vector<uint32_t> eventTofs;
-  EXPECT_TRUE(fileReader.getEventTofs(eventTofs, 0, 0));
-  EXPECT_EQ(numberOfFakeEventsPerPulse, eventTofs.size());
+  std::vector<EventDataFrame> eventData;
+  EXPECT_TRUE(fileReader.getEventData(eventData, 0));
+  EXPECT_EQ(numberOfFakeEventsPerPulse, eventData[0].timeOfFlights.size());
 }
 
 TEST(NexusFileReaderTest,
@@ -126,23 +126,16 @@ TEST(NexusFileReaderTest,
   auto fileReader =
       NexusFileReader(hdf5::file::open(testDataPath + "SANS_test.nxs"), 0,
                       numberOfFakeEventsPerPulse, {0});
-  std::vector<uint32_t> detIDs;
-  EXPECT_TRUE(fileReader.getEventDetIds(detIDs, 0, 0));
-  EXPECT_EQ(numberOfFakeEventsPerPulse, detIDs.size());
+  std::vector<EventDataFrame> eventData;
+  EXPECT_TRUE(fileReader.getEventData(eventData, 0));
+  EXPECT_EQ(numberOfFakeEventsPerPulse, eventData[0].detectorIDs.size());
 }
 
-TEST(NexusFileReaderTest, get_detIds_too_high_frame_number) {
+TEST(NexusFileReaderTest, get_eventData_too_high_frame_number) {
   auto fileReader = NexusFileReader(
       hdf5::file::open(testDataPath + "SANS_test.nxs"), 0, 0, {0});
-  std::vector<uint32_t> detIds;
-  EXPECT_FALSE(fileReader.getEventDetIds(detIds, 3000000, 0));
-}
-
-TEST(NexusFileReaderTest, get_event_tofs_too_high_frame_number) {
-  auto fileReader = NexusFileReader(
-      hdf5::file::open(testDataPath + "SANS_test.nxs"), 0, 0, {0});
-  std::vector<uint32_t> eventTofs;
-  EXPECT_FALSE(fileReader.getEventTofs(eventTofs, 3000000, 0));
+  std::vector<EventDataFrame> eventData;
+  EXPECT_FALSE(fileReader.getEventData(eventData, 3000000));
 }
 
 TEST(NexusFileReaderTest, get_period_number) {

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -15,8 +15,7 @@ public:
   NexusPublisher(std::shared_ptr<EventPublisher> publisher,
                  std::shared_ptr<FileReader> fileReader,
                  const OptionalArgs &settings);
-  std::vector<std::shared_ptr<EventData>>
-  createMessageData(hsize_t frameNumber);
+  std::vector<EventData> createMessageData(hsize_t frameNumber);
   size_t createAndSendRunMessage(int runNumber);
   size_t createAndSendDetSpecMessage();
   std::shared_ptr<RunData> createRunMessageData(int runNumber);

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -121,6 +121,7 @@ void NexusPublisher::streamData(int runNumber, bool slow,
   }
   totalBytesSent += createAndSendRunStopMessage();
   reportProgress(1.0);
+  std::cout << std::endl;
 
   m_logger->info("Frames sent: {}, Bytes sent: {}",
                  m_fileReader->getNumberOfFrames(), totalBytesSent);

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -15,17 +15,11 @@ class FakeFileReader : public FileReader {
   uint32_t getPeriodNumber() override { return 0; };
   float getProtonCharge(hsize_t frameNumber) override { return 0.002; };
 
-  bool getEventDetIds(std::vector<uint32_t> &detIds, hsize_t frameNumber,
-                      size_t eventGroupNumber) override {
-    detIds = {0, 1, 2};
+  bool getEventData(std::vector<EventDataFrame> &eventData,
+                    hsize_t frameNumber) override {
+    eventData.push_back(EventDataFrame({0, 1, 2}, {0, 1, 2}));
     return true;
-  };
-
-  bool getEventTofs(std::vector<uint32_t> &tofs, hsize_t frameNumber,
-                    size_t eventGroupNumber) override {
-    tofs = {0, 1, 2};
-    return true;
-  };
+  }
 
   size_t getNumberOfFrames() override { return 1; };
   hsize_t getNumberOfEventsInFrame(hsize_t frameNumber,
@@ -78,7 +72,7 @@ TEST_F(NexusPublisherTest, test_create_message_data) {
   auto streamer = createStreamer(true);
   auto eventData = streamer.createMessageData(static_cast<hsize_t>(0));
 
-  auto buffer = eventData[0]->getBuffer(0);
+  auto buffer = eventData[0].getBuffer(0);
 
   auto receivedEventData = EventData();
   EXPECT_TRUE(receivedEventData.decodeMessage(

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -36,6 +36,9 @@ class FakeFileReader : public FileReader {
     return 0;
   };
   bool isISISFile() override { return true; };
+  uint64_t getTotalEventsInGroup(size_t eventGroupNumber) override {
+    return 3;
+  };
 };
 
 class NexusPublisherTest : public ::testing::Test {


### PR DESCRIPTION
### Description of work

Publish data from all event groups in a file.
The current implementation will only do this if all groups have the same pulse information (same `event_time_zero` dataset in every `NXevent_data` group). If this is not the case a warning is logged and only data from one of the groups is published.

### Issue

Closes #81

### Acceptance Criteria

Please review changes and check there are sufficient new tests.

### Unit Tests

Added two tests to `NexusFileReaderTest`.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
