### PR TITLE
Fix increasing message size when using random generated events and multiple event groups

### DIFF
--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -32,8 +32,10 @@ public:
   uint64_t getTotalEventsInGroup(size_t eventGroupNumber) override;
 
 private:
-  std::vector<uint32_t> getEventDetIds(hsize_t frameNumber, size_t eventGroupNumber);
-  std::vector<uint32_t> getEventTofs(hsize_t frameNumber, size_t eventGroupNumber);
+  std::vector<uint32_t> getEventDetIds(hsize_t frameNumber,
+                                       size_t eventGroupNumber);
+  std::vector<uint32_t> getEventTofs(hsize_t frameNumber,
+                                     size_t eventGroupNumber);
   void getEntryGroup(const hdf5::node::Group &rootGroup,
                      hdf5::node::Group &entryGroupOutput);
   void getEventGroups(const hdf5::node::Group &entryGroup,

--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -32,10 +32,8 @@ public:
   uint64_t getTotalEventsInGroup(size_t eventGroupNumber) override;
 
 private:
-  bool getEventDetIds(std::vector<uint32_t> &detIds, hsize_t frameNumber,
-                      size_t eventGroupNumber);
-  bool getEventTofs(std::vector<uint32_t> &tofs, hsize_t frameNumber,
-                    size_t eventGroupNumber);
+  std::vector<uint32_t> getEventDetIds(hsize_t frameNumber, size_t eventGroupNumber);
+  std::vector<uint32_t> getEventTofs(hsize_t frameNumber, size_t eventGroupNumber);
   void getEntryGroup(const hdf5::node::Group &rootGroup,
                      hdf5::node::Group &entryGroupOutput);
   void getEventGroups(const hdf5::node::Group &entryGroup,

--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -406,9 +406,11 @@ hsize_t NexusFileReader::getNumberOfEventsInFrame(hsize_t frameNumber,
  * Get the list of detector IDs corresponding to events in the specified frame
  *
  * @param frameNumber - the number of the frame in which to get the detector IDs
- * @return - vector of detIds, empty if the specified frame number is not the data range
+ * @return - vector of detIds, empty if the specified frame number is not the
+ * data range
  */
-std::vector<uint32_t> NexusFileReader::getEventDetIds(hsize_t frameNumber, size_t eventGroupNumber) {
+std::vector<uint32_t> NexusFileReader::getEventDetIds(hsize_t frameNumber,
+                                                      size_t eventGroupNumber) {
   if (frameNumber >= m_numberOfFrames)
     return {};
 
@@ -442,13 +444,13 @@ std::vector<uint32_t> NexusFileReader::getEventDetIds(hsize_t frameNumber, size_
 /**
  * Get the list of flight times corresponding to events in the specifed frame
  *
- * @param tofs - vector in which to store the time-of-flight
  * @param frameNumber - the number of the frame in which to get the
  * time-of-flights
- * @return - false if the specified frame number is not the data range, true
- * otherwise
+ * @return - vector of flight times, empty if the specified frame number is not
+ * the data range
  */
-std::vector<uint32_t> NexusFileReader::getEventTofs(hsize_t frameNumber, size_t eventGroupNumber) {
+std::vector<uint32_t> NexusFileReader::getEventTofs(hsize_t frameNumber,
+                                                    size_t eventGroupNumber) {
   if (frameNumber >= m_numberOfFrames)
     return {};
 

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -58,7 +58,8 @@ int main(int argc, char **argv) {
   App.add_option("-m,--compression", settings.compression,
                  "Compression option for Kafka messages");
   App.add_option("-e,--fake-events-per-pulse", settings.fakeEventsPerPulse,
-                 "Generates this number of fake events per pulse per NXevent_data instead of "
+                 "Generates this number of fake events per pulse per "
+                 "NXevent_data instead of "
                  "publishing real data from file");
   App.add_option(
          "-x,--disable-map",

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
   App.add_option("-m,--compression", settings.compression,
                  "Compression option for Kafka messages");
   App.add_option("-e,--fake-events-per-pulse", settings.fakeEventsPerPulse,
-                 "Generates this number of fake events per pulse instead of "
+                 "Generates this number of fake events per pulse per NXevent_data instead of "
                  "publishing real data from file");
   App.add_option(
          "-x,--disable-map",


### PR DESCRIPTION
### Description of work

Generated events for each `NXevent_data` in the file were being concatenated within each frame. This lead to much bigger event messages than expected in the case that there were several event groups.

### Issue

Closes #87

### Acceptance Criteria

Check that the added unit test makes is clear and covers what was intended.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
