### PR TITLE
Fix bug streaming LOKI data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN cd nexus_streamer && conan install --build=outdated ../nexus_streamer_src/co
 
 # Build NeXus-Streamer
 COPY cmake nexus_streamer_src/cmake/
-COPY event_data nexus_streamer_src/event_data/
+COPY serialisation nexus_streamer_src/serialisation/
 COPY nexus_file_reader nexus_streamer_src/nexus_file_reader/
 COPY nexus_producer nexus_streamer_src/nexus_producer/
 COPY core nexus_streamer_src/core/

--- a/nexus_file_reader/include/FileReader.h
+++ b/nexus_file_reader/include/FileReader.h
@@ -31,4 +31,5 @@ public:
   virtual bool isISISFile() = 0;
   virtual uint64_t getTotalEventsInGroup(size_t eventGroupNumber) = 0;
   virtual uint32_t getRunDurationMs() = 0;
+  virtual bool hasHistogramData() = 0;
 };

--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -32,6 +32,7 @@ public:
   bool isISISFile() override;
   uint64_t getTotalEventsInGroup(size_t eventGroupNumber) override;
   uint32_t getRunDurationMs() override;
+  bool hasHistogramData() override { return !m_histoGroups.empty(); };
 
 private:
   std::vector<uint32_t> getEventDetIds(hsize_t frameNumber,

--- a/nexus_file_reader/test/NexusFileReaderTest.cpp
+++ b/nexus_file_reader/test/NexusFileReaderTest.cpp
@@ -412,3 +412,27 @@ TEST(NexusFileReaderTest, run_duration_throws_if_no_duration_dataset_present) {
   auto fileReader = NexusFileReader(file, 0, 0, {0});
   EXPECT_THROW(fileReader.getRunDurationMs(), std::runtime_error);
 }
+
+TEST(NexusFileReaderTest,
+     hasHistogramData_returns_false_if_no_histogram_data_in_file) {
+  auto file = createInMemoryTestFile("dataFileWithDurationDataset");
+  HDF5FileTestHelpers::addNXentryToFile(file, "entry");
+  HDF5FileTestHelpers::addNXeventDataToFile(file, "entry");
+  HDF5FileTestHelpers::addNXeventDataDatasetsToFile(file, "entry");
+  auto fileReader = NexusFileReader(file, 0, 0, {0});
+
+  EXPECT_FALSE(fileReader.hasHistogramData());
+}
+
+TEST(NexusFileReaderTest,
+     hasHistogramData_returns_true_if_histogram_data_in_file) {
+  auto file = createInMemoryTestFile("dataFileWithNoDuration");
+  HDF5FileTestHelpers::addNXentryToFile(file, "entry");
+
+  HDF5FileTestHelpers::addHistogramDataGroupToFile(
+      file, "entry", "detector_1", {1, 2, 3, 4}, {1}, 2, 2,
+      {5.0, 4005.0, 8005.0, 12005.0, 16005.0, 19995.0});
+  auto fileReader = NexusFileReader(file, 0, 0, {0});
+
+  EXPECT_TRUE(fileReader.hasHistogramData());
+}

--- a/nexus_file_reader/test/NexusFileReaderTest.cpp
+++ b/nexus_file_reader/test/NexusFileReaderTest.cpp
@@ -415,7 +415,9 @@ TEST(NexusFileReaderTest, run_duration_throws_if_no_duration_dataset_present) {
 
 TEST(NexusFileReaderTest,
      hasHistogramData_returns_false_if_no_histogram_data_in_file) {
-  auto file = createInMemoryTestFile("dataFileWithDurationDataset");
+  auto file = createInMemoryTestFile("dataFileWithNoHistogramData");
+
+  // Add event data but no histogram data
   HDF5FileTestHelpers::addNXentryToFile(file, "entry");
   HDF5FileTestHelpers::addNXeventDataToFile(file, "entry");
   HDF5FileTestHelpers::addNXeventDataDatasetsToFile(file, "entry");
@@ -426,7 +428,7 @@ TEST(NexusFileReaderTest,
 
 TEST(NexusFileReaderTest,
      hasHistogramData_returns_true_if_histogram_data_in_file) {
-  auto file = createInMemoryTestFile("dataFileWithNoDuration");
+  auto file = createInMemoryTestFile("dataFileWithHistogramData");
   HDF5FileTestHelpers::addNXentryToFile(file, "entry");
 
   HDF5FileTestHelpers::addHistogramDataGroupToFile(

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -171,6 +171,11 @@ void NexusPublisher::streamData(int runNumber, const OptionalArgs &settings) {
 
 std::unique_ptr<Timer>
 NexusPublisher::streamHistogramData(const OptionalArgs &settings) {
+  std::unique_ptr<Timer> histogramStreamer;
+  if (!m_fileReader->hasHistogramData()) {
+    return histogramStreamer;
+  }
+
   auto runDurationMs = m_fileReader->getRunDurationMs();
 
   int32_t numberOfHistogramUpdates =
@@ -180,7 +185,6 @@ NexusPublisher::streamHistogramData(const OptionalArgs &settings) {
   numberOfHistogramUpdates = std::max(1, numberOfHistogramUpdates);
 
   auto histograms = m_fileReader->getHistoData();
-  std::unique_ptr<Timer> histogramStreamer;
 
   // If the duration of the run is longer/similar to the specified update period
   // for histogram data, or if slow mode was not selected then we are


### PR DESCRIPTION
### Description of work

Fixes bug which caused event data streaming to fail if there is no histogram data in file.

### Issue

Closes #96

### Acceptance Criteria

Check new tests are comprehensible and pass.

### Unit Tests

New unit test covers the bug behaviour:
```
TEST_F(NexusPublisherTest,
       event_data_is_streamed_even_if_no_histogram_data_is_present_in_file)
```

Tests also added in `NexusFileReaderTest` to cover new function added: `fileReader.hasHistogramData()`

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
