### PR TITLE
H5cpp update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,9 +99,7 @@ file(GLOB TEST_SRC_FILES
 add_executable(UnitTests ${TEST_SRC_FILES})
 
 target_link_libraries(UnitTests
-        CONAN_PKG::gtest
         CONAN_PKG::cli11
-        CONAN_PKG::h5cpp
         producerUnitTests
         eventDataUnitTests
         fileReaderUnitTests)

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -4,8 +4,8 @@ librdkafka/0.11.5@ess-dmsc/stable
 gtest/3121b20-dm3@ess-dmsc/stable
 cli11/1.6.0@bincrafters/stable
 google-benchmark/4c2af07-dm3@ess-dmsc/stable
-spdlog/1.1.0@bincrafters/stable
-FlatBuffers/1.10.0@ess-dmsc/stable
+spdlog/1.3.1@bincrafters/stable
+FlatBuffers/1.10.0-dm1@ess-dmsc/stable
 streaming-data-types/6cd05e4@ess-dmsc/stable
 
 [generators]

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-h5cpp/0.1.0@ess-dmsc/testing
+h5cpp/0.1.3@ess-dmsc/stable
 librdkafka/0.11.5@ess-dmsc/stable
 gtest/3121b20-dm3@ess-dmsc/stable
 cli11/1.6.0@bincrafters/stable

--- a/nexus_file_reader/CMakeLists.txt
+++ b/nexus_file_reader/CMakeLists.txt
@@ -23,7 +23,6 @@ add_library(nexusFileReader_lib ${SRC_FILES} ${INC_FILES})
 
 target_link_libraries(nexusFileReader_lib
         serialisation_lib
-        CONAN_PKG::hdf5
         CONAN_PKG::h5cpp
         CONAN_PKG::spdlog)
 


### PR DESCRIPTION
### Description of work

The old h5cpp package no longer works due to a broken boost package.
Seems to require `activate_run.sh` now, despite the fact that daquiri uses this package version and does not require `activate_run.sh`.  Created ticket for this #101
