### PR TITLE
Removing annoying codecov patch check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,10 +6,7 @@ comment:
   require_changes: no
 coverage:
   status:
-    patch:
-      default:
-        target: auto
-        threshold: 5
+    patch: off
     project:
       default:
         target: auto


### PR DESCRIPTION
### Description of work

Removing the patch comment. We did this on the forwarder and filewriter as it was reporting incorrectly that the CI had failed. I can turn off the other requirement (project coverage) too if needed so it's exactly the same as the forwarder and filewriter. 

### Issue

None

### Acceptance Criteria

No changes in functionality. 

### Unit Tests

N/A

### Other

N/A

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
