### PR TITLE
Increase allowed message size on docker broker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,8 @@ services:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ADVERTISED_PORT: 9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_MESSAGE_MAX_BYTES: 100000000
+      KAFKA_MESSAGE_MAX_BYTES: 200000000
+      KAFKA_SOCKET_REQUEST_MAX_BYTES: 200000000
       KAFKA_BROKER_ID: 0
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/nexus_producer/src/KafkaPublisher.cpp
+++ b/nexus_producer/src/KafkaPublisher.cpp
@@ -68,7 +68,7 @@ void KafkaPublisher::setUp(const std::string &broker,
  * Wait for all messages in the current producer queue to be published
  */
 void KafkaPublisher::flushSendQueue() {
-  auto error = m_producer_ptr->flush(2000);
+  auto error = m_producer_ptr->flush(300000);
   if (error != RdKafka::ERR_NO_ERROR) {
     m_logger->error("Producer queue flush failed.");
   }


### PR DESCRIPTION
### Description of work

For the sake of streaming LOKI geometry (message size >150MB).

