### PR TITLE
Fix json generation for chopper timestamps

### DIFF
--- a/generate_json/generate_json_description.py
+++ b/generate_json/generate_json_description.py
@@ -131,6 +131,7 @@ class NexusToDictConverter:
         is_stream = False
         if isinstance(root, nexus.NXlog):
             stream_info["writer_module"] = "f142"
+            is_stream = True
             if root.nxname == 'value_log':
                 # For ISIS files the parent of the NXlog has a more useful name
                 # which the NeXus-Streamer uses as the source name
@@ -138,8 +139,13 @@ class NexusToDictConverter:
             else:
                 stream_info["source"] = root.nxname
             stream_info["topic"] = "SAMPLE_ENV_TOPIC"
-            stream_info["dtype"] = self._get_dtype(root.entries['value'])
-            is_stream = True
+            try:
+                stream_info["dtype"] = self._get_dtype(root.entries['value'])
+            except KeyError:
+                try:
+                    stream_info["dtype"] = self._get_dtype(root.entries['raw_value'])
+                except KeyError:
+                    is_stream = False
         elif isinstance(root, nexus.NXevent_data):
             stream_info["writer_module"] = "ev42"
             stream_info["topic"] = "EVENT_DATA_TOPIC"

--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -38,6 +38,8 @@ public:
   bool hasHistogramData() override { return !m_histoGroups.empty(); };
 
 private:
+  void getEventGroups(const hdf5::node::Group &entryGroup,
+                      std::vector<hdf5::node::Group> &eventGroupsOutput);
   void
   findEventGroupsInDetectors(const hdf5::node::Group &rootGroup,
                              std::vector<hdf5::node::Group> &groupsOutput,

--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -38,13 +38,17 @@ public:
   bool hasHistogramData() override { return !m_histoGroups.empty(); };
 
 private:
+  void
+  findEventGroupsInDetectors(const hdf5::node::Group &rootGroup,
+                             std::vector<hdf5::node::Group> &groupsOutput,
+                             const std::vector<std::string> &requiredDatasets);
   std::vector<uint32_t> getEventDetIds(hsize_t frameNumber,
                                        size_t eventGroupNumber);
   std::vector<uint32_t> getEventTofs(hsize_t frameNumber,
                                      size_t eventGroupNumber);
   static void getEntryGroup(const hdf5::node::Group &rootGroup,
                             hdf5::node::Group &entryGroupOutput);
-  void getGroups(const hdf5::node::Group &entryGroup,
+  void getGroups(const hdf5::node::Group &parentGroup,
                  std::vector<hdf5::node::Group> &groupsOutput,
                  const std::string &className,
                  const std::vector<std::string> &requiredDatasets);

--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -61,15 +61,20 @@ NexusFileReader::NexusFileReader(hdf5::file::File file, uint64_t runStartTime,
     throw std::runtime_error("Failed to open specified NeXus file");
   }
   getEntryGroup(m_file.root(), m_entryGroup);
-  getGroups(
-      m_entryGroup, m_eventGroups, "NXevent_data",
-      {"event_time_zero", "event_time_offset", "event_id", "event_index"});
+  const std::vector<std::string> requiredEventDatasets = {
+      "event_time_zero", "event_time_offset", "event_id", "event_index"};
+  getGroups(m_entryGroup, m_eventGroups, "NXevent_data", requiredEventDatasets);
   getGroups(m_entryGroup, m_histoGroups, "NXdata",
             {"time_of_flight", "counts"});
 
   if (m_eventGroups.empty() && m_histoGroups.empty()) {
-    throw std::runtime_error(
-        "No valid NXevent_data or NXdata groups found in the NXentry group");
+    // Last thing to try is looking for event data in detector groups
+    findEventGroupsInDetectors(m_entryGroup, m_eventGroups,
+                               requiredEventDatasets);
+    if (m_eventGroups.empty()) {
+      throw std::runtime_error(
+          "No valid NXevent_data or NXdata groups found in the NXentry group");
+    }
   }
 
   m_isisFile = testIfIsISISFile();
@@ -96,6 +101,28 @@ NexusFileReader::NexusFileReader(hdf5::file::File file, uint64_t runStartTime,
   m_frameStartOffset = m_runStart;
 }
 
+void NexusFileReader::findEventGroupsInDetectors(
+    const hdf5::node::Group &rootGroup,
+    std::vector<hdf5::node::Group> &eventGroupsOutput,
+    const std::vector<std::string> &requiredDatasets) {
+  std::vector<hdf5::node::Group> instrumentGroups;
+  getGroups(rootGroup, instrumentGroups, "NXinstrument", {});
+  if (instrumentGroups.empty()) {
+    return;
+  }
+
+  std::vector<hdf5::node::Group> detectorGroups;
+  getGroups(instrumentGroups[0], detectorGroups, "NXdetector", {});
+  if (detectorGroups.empty()) {
+    return;
+  }
+
+  for (auto &detectorGroup : detectorGroups) {
+    getGroups(detectorGroup, eventGroupsOutput, "NXevent_data",
+              requiredDatasets);
+  }
+}
+
 void NexusFileReader::getEntryGroup(const hdf5::node::Group &rootGroup,
                                     hdf5::node::Group &entryGroupOutput) {
   for (const auto &rootChild : rootGroup.nodes) {
@@ -114,10 +141,10 @@ void NexusFileReader::getEntryGroup(const hdf5::node::Group &rootGroup,
 }
 
 void NexusFileReader::getGroups(
-    const hdf5::node::Group &entryGroup,
+    const hdf5::node::Group &parentGroup,
     std::vector<hdf5::node::Group> &groupsOutput, const std::string &className,
     const std::vector<std::string> &requiredDatasets) {
-  for (const auto &entryChild : entryGroup.nodes) {
+  for (const auto &entryChild : parentGroup.nodes) {
     if (entryChild.attributes.exists("NX_class")) {
       auto attr = entryChild.attributes["NX_class"];
       std::string nxClassType;
@@ -143,6 +170,12 @@ void NexusFileReader::checkGroupHasRequiredDatasets(
     if (!group.has_dataset(datasetName)) {
       throw std::runtime_error(
           fmt::format("Required dataset {} missing from {} group at {}",
+                      datasetName, className, group.link().path().name()));
+    }
+    hdf5::node::Dataset dataset = group[datasetName];
+    if (dataset.dataspace().size() == 0) {
+      throw std::runtime_error(
+          fmt::format("Required dataset {} is empty in {} group at {}",
                       datasetName, className, group.link().path().name()));
     }
   }


### PR DESCRIPTION
### Description of work

Chopper timestamp NXlog groups don't have a value dataset which was causing a problem when trying to generate the JSON description.
